### PR TITLE
Allow positions stored as lists in a single attribute

### DIFF
--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -118,7 +118,7 @@ class TrackingGraph:
             The name of the node attribute that corresponds to the frame of
             the node. Defaults to "t".
         location_keys: tuple of str | str
-            Keys used to access the location of the cell in space.
+            Key(s) used to access the location of the cell in space.
     """
 
     def __init__(
@@ -153,9 +153,10 @@ class TrackingGraph:
                 'segmentation_id'. Pass `None` if there is not a label
                 attribute on the graph.
             location_key (str | tuple, optional): The key or list of keys on each node
-                in graph that contains the spatial location of the node. Every
+                in graph that contains the spatial location of the node, in the order
+                needed to index the segmentation, if applicable. Every
                 node must have a value stored at each of these provided keys.
-                If a single string, it is assume that the location is stored as a list
+                If a single string, it is assumed that the location is stored as a list
                 on each node in a single attribute. Defaults to ('x', 'y').
             name (str, optional): User specified name that will be included in result
                 outputs associated with this object

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -65,6 +65,24 @@ class NodeFlag(str, enum.Enum):
         return value in cls.__members__.values()
 
 
+def _check_valid_key_name(key: str, name: str) -> None:
+    """Check if the provided key conflicts with the reserved NodeFlag values and raise
+    a ValueError if so.
+
+    Args:
+        key (str): The key to check if it conflicts with the reserved values
+        name (str): The name of key to use in the error message
+
+    Raises:
+        ValueError: if the provided key conflicts with the NodeFlag values
+    """
+    if NodeFlag.has_value(key):
+        raise ValueError(
+            f"Specified {name} key {key} is reserved for graph"
+            f"annotation. Please change the {name} key."
+        )
+
+
 @enum.unique
 class EdgeFlag(str, enum.Enum):
     """An enum containing standard flags that are used to
@@ -171,13 +189,6 @@ class TrackingGraph:
                 "annotation. Please change the frame key."
             )
         self.frame_key = frame_key
-
-        def _check_valid_key_name(key: str, name: str) -> None:
-            if NodeFlag.has_value(key):
-                raise ValueError(
-                    f"Specified {name} key {key} is reserved for graph"
-                    f"annotation. Please change the {name} key."
-                )
 
         if label_key is not None:
             _check_valid_key_name(label_key, "label")

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -117,7 +117,7 @@ class TrackingGraph:
         frame_key: str
             The name of the node attribute that corresponds to the frame of
             the node. Defaults to "t".
-        location_key: tuple of str | str
+        location_keys: tuple of str | str
             Keys used to access the location of the cell in space.
     """
 

--- a/src/traccuracy/matchers/_point.py
+++ b/src/traccuracy/matchers/_point.py
@@ -77,9 +77,9 @@ class PointMatcher(Matcher):
     def _match_frame(
         self,
         gt_nodes: list[Hashable],
-        gt_locations: list[list[float]],
+        gt_locations: list[list[float] | tuple[float] | np.ndarray],
         pred_nodes: list[Hashable],
-        pred_locations: list[list[float]],
+        pred_locations: list[list[float] | tuple[float] | np.ndarray],
     ) -> list[tuple[Any, Any]]:
         mapping: list[tuple[Any, Any]] = []
         if len(gt_nodes) == 0 or len(pred_nodes) == 0:

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -78,7 +78,7 @@ class PointSegMatcher(Matcher):
 
 
 def match_point_to_seg(
-    node_ids: list[Hashable], locs: list[list[float]], seg: np.ndarray
+    node_ids: list[Hashable], locs: list[list[float] | np.ndarray | tuple[float]], seg: np.ndarray
 ) -> dict[Hashable, int]:
     """For a single timepoint, identify the segmentation ids which a set of points index into
 

--- a/tests/matchers/test_point.py
+++ b/tests/matchers/test_point.py
@@ -1,4 +1,5 @@
 import copy
+import re
 
 import networkx as nx
 import numpy as np
@@ -232,9 +233,17 @@ class TestPointMatcher:
     n_labels = 3
     track_graph = get_movie_with_graph(ndims=3, n_frames=n_frames, n_labels=n_labels)
 
-    def test_empty(self):
+    def test_no_loc_key(self):
         data = TrackingGraph(self.track_graph.graph)
-        empty = TrackingGraph(nx.DiGraph())
+        matcher = PointMatcher(threshold=5)
+        with pytest.raises(
+            ValueError, match=re.escape("Must provide location key(s) to access node locations")
+        ):
+            matcher.compute_mapping(data, data)
+
+    def test_empty(self):
+        data = self.track_graph
+        empty = TrackingGraph(nx.DiGraph(), location_keys=data.location_keys)
         matcher = PointMatcher(threshold=5)
         matched = matcher.compute_mapping(data, empty)
         assert matched.matcher_info["name"] == "PointMatcher"
@@ -251,7 +260,7 @@ class TestPointMatcher:
         assert len(matched.mapping) == 0
 
     def test_no_segmentation(self):
-        data = TrackingGraph(self.track_graph.graph)
+        data = self.track_graph
         matcher = PointMatcher(threshold=5)
         matched = matcher.compute_mapping(data, data)
         assert matched.matcher_info["name"] == "PointMatcher"

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -158,7 +158,7 @@ def test_constructor_and_get_location(graph_name, location_key, request):
         2: {"1_2", "1_3"},
         3: {"1_4"},
     }
-    assert tracking_graph.get_location("1_0") == [1, 1]
+    assert tracking_graph.get_location("1_3") == [1, 2]
 
 
 def test_invalid_constructor(nx_comp1):

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -1,3 +1,4 @@
+import re
 from collections import Counter
 
 import networkx as nx
@@ -131,17 +132,17 @@ def nx_merge():
 
 @pytest.fixture
 def merge_graph(nx_merge):
-    return TrackingGraph(nx_merge)
+    return TrackingGraph(nx_merge, location_keys=("y", "x"))
 
 
 @pytest.fixture
 def simple_graph(nx_comp1):
-    return TrackingGraph(nx_comp1)
+    return TrackingGraph(nx_comp1, location_keys=("y", "x"))
 
 
 @pytest.fixture
 def complex_graph(nx_comp1, nx_comp2):
-    return TrackingGraph(nx.compose(nx_comp1, nx_comp2))
+    return TrackingGraph(nx.compose(nx_comp1, nx_comp2), location_keys=("y", "x"))
 
 
 @pytest.mark.parametrize(
@@ -159,6 +160,22 @@ def test_constructor_and_get_location(graph_name, location_key, request):
         3: {"1_4"},
     }
     assert tracking_graph.get_location("1_3") == [1, 2]
+
+
+def test_no_location(nx_comp1):
+    tracking_graph = TrackingGraph(nx_comp1)
+    assert tracking_graph.start_frame == 0
+    assert tracking_graph.end_frame == 4
+    assert tracking_graph.nodes_by_frame == {
+        0: {"1_0"},
+        1: {"1_1"},
+        2: {"1_2", "1_3"},
+        3: {"1_4"},
+    }
+    with pytest.raises(
+        ValueError, match=re.escape("Must provide location key(s) to access node locations")
+    ):
+        tracking_graph.get_location("1_3")
 
 
 def test_invalid_constructor(nx_comp1):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -130,7 +130,7 @@ def get_movie_with_graph(ndims=3, n_frames=3, n_labels=3):
             for i in range(1, n_labels + 1):
                 G.add_edge(f"{i}_{t - 1}", f"{i}_{t}")
 
-    return TrackingGraph(G, segmentation=movie)
+    return TrackingGraph(G, segmentation=movie, location_keys=pos_keys)
 
 
 def get_division_graphs():


### PR DESCRIPTION
# Proposed Change
Expands set of valid location keys to include a single location key holding a list of values, along with the existing tuple of keys holding one value each.

# Types of Changes
What types of changes does your code introduce?
- New feature or enhancement
- Tests and benchmarks

Which topics does your change affect? 
- Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).

# Further Comments
We could rename the argument to "location_key", but that is a breaking change.
We could also pick one type of location key instead of supporting both formats, but that is another big breaking change. I've found needing to rewrite all the attributes on my nodes to be a pretty big usability barrier, and supporting both is a small code burden, so I'm in favor of keeping both options.