### PR TITLE
Pin click dependency to avoid docs build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "click<8.2.0",
     "numpy",
     "networkx",
     "pandas",


### PR DESCRIPTION
# Proposed Change
I think the latest `click` release (dependency of typer) broke `sphinx-click` because we get a [typer](https://app.readthedocs.org/projects/traccuracy/builds/28136770/#270632679--199) error when building CLI docs. Click was released last night. I've confirmed this locally on `main` as well - I actually don't know how to trigger a docs build without a commit, using the `pixi` workflow? But if I pin `click<8.2.0` it passes locally so I'm trying that here.

# Types of Changes
- Maintenance (e.g. dependencies, CI, releases, etc.)
