### PR TITLE
Add TF measure to track_overlap

### DIFF
--- a/src/traccuracy/metrics/_track_overlap.py
+++ b/src/traccuracy/metrics/_track_overlap.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from traccuracy.matchers._base import Matched
 
 from ._base import Metric
@@ -46,7 +48,7 @@ class TrackOverlapMetrics(Metric):
         super().__init__(valid_match_types)
         self.include_division_edges = include_division_edges
 
-    def _compute(self, matched: Matched) -> dict[str, float]:
+    def _compute(self, matched: Matched) -> dict[str, float | np.floating[Any]]:
         gt_tracklets = matched.gt_graph.get_tracklets(
             include_division_edges=self.include_division_edges
         )
@@ -55,13 +57,14 @@ class TrackOverlapMetrics(Metric):
         )
 
         # calculate track purity and target effectiveness
-        track_purity = _calc_overlap_score(pred_tracklets, gt_tracklets, matched.pred_gt_map)
-        target_effectiveness = _calc_overlap_score(
+        track_purity, _ = _calc_overlap_score(pred_tracklets, gt_tracklets, matched.pred_gt_map)
+        target_effectiveness, track_fractions = _calc_overlap_score(
             gt_tracklets, pred_tracklets, matched.gt_pred_map
         )
         return {
             "track_purity": track_purity,
             "target_effectiveness": target_effectiveness,
+            "track_fractions": track_fractions,
         }
 
 
@@ -69,9 +72,13 @@ def _calc_overlap_score(
     reference_tracklets: list[nx.DiGraph],
     overlap_tracklets: list[nx.DiGraph],
     overlap_reference_mapping: dict[Any, list[Any]],
-) -> float:
-    """Calculate weighted sum of the length of the longest overlap tracklet
-    for each reference tracklet.
+) -> tuple[float | np.floating[Any], float | np.floating[Any]]:
+    """Get weighted/unweighted fraction of reference_tracklets overlapped by overlap_tracklets.
+
+    The weighted average is calculated as the total number of maximally
+    overlapping edges divided by the total number of edges in the reference tracklets.
+    The unweighted average is calculated as the mean of the fraction of maximally
+    overlapping edges for each reference tracklet.
 
     Args:
         reference_tracklets (List[TrackingGraph]): The reference tracklets
@@ -79,9 +86,13 @@ def _calc_overlap_score(
         overlap_reference_mapping (Dict[Any, List[Any]]): Mapping as a dict
             from the overlap tracklet nodes to the reference tracklet nodes
 
+    Returns:
+        tuple[float | np.floating[Any], float | np.floating[Any]]: A tuple containing the
+            weighted and unweighted averages of the overlap fractions.
     """
     max_overlap = 0
     total_count = 0
+    track_fractions = []
     overlap_edge_to_tid = {
         edge: i for i in range(len(overlap_tracklets)) for edge in overlap_tracklets[i].edges()
     }
@@ -97,5 +108,10 @@ def _calc_overlap_score(
                 if (src, tgt) in overlap_edge_to_tid:
                     overlapping_id_to_count[overlap_edge_to_tid[(src, tgt)]] += 1
         total_count += tracklet_length
-        max_overlap += max(overlapping_id_to_count.values(), default=0)
-    return max_overlap / total_count if total_count > 0 else -1
+        tracklet_overlap = max(overlapping_id_to_count.values(), default=0)
+        max_overlap += tracklet_overlap
+        if tracklet_length:
+            track_fractions.append(tracklet_overlap / tracklet_length)
+    weighted_average = max_overlap / total_count if total_count > 0 else np.nan
+    unweighted_average = np.mean(track_fractions) if track_fractions else np.nan
+    return weighted_average, unweighted_average

--- a/tests/metrics/test_track_overlap_metrics.py
+++ b/tests/metrics/test_track_overlap_metrics.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import networkx as nx
+import numpy as np
 import pytest
 
 from tests.examples import graphs as ex_graphs
@@ -60,10 +61,12 @@ TEST_TREES = [
         "results_with_division_edges": {
             "track_purity": 7 / 9,
             "target_effectiveness": 6 / 11,
+            "track_fractions": 7 / 12,
         },
         "results_without_division_edges": {
             "track_purity": 5 / 7,
             "target_effectiveness": 6 / 9,
+            "track_fractions": 2 / 3,
         },
     },
     {
@@ -104,10 +107,12 @@ TEST_TREES = [
         "results_with_division_edges": {
             "track_purity": 5 / 6,
             "target_effectiveness": 4 / 5,
+            "track_fractions": 2.5 / 3,
         },
         "results_without_division_edges": {
             "track_purity": 3 / 4,
             "target_effectiveness": 2 / 3,
+            "track_fractions": 2 / 3,
         },
     },
 ]
@@ -131,10 +136,12 @@ simple2["pred_edges"].extend(
 simple2["results_with_division_edges"] = {
     "track_purity": 7 / 11,
     "target_effectiveness": 5 / 11,
+    "track_fractions": 6 / 12,
 }
 simple2["results_without_division_edges"] = {
     "track_purity": 5 / 7,
     "target_effectiveness": 5 / 9,
+    "track_fractions": 7 / 12,
 }
 TEST_TREES.append(simple2)
 assert TEST_TREES[0] != TEST_TREES[1]
@@ -166,7 +173,12 @@ def test_track_overlap_metrics(data, inverse) -> None:
             "track_purity": expected["target_effectiveness"],
             "target_effectiveness": expected["track_purity"],
         }
-    assert results == expected, f"{data['name']} failed with division edges"
+        results.pop("track_fractions", None)
+    np.testing.assert_allclose(
+        list(results.values()),
+        list(expected.values()),
+        err_msg=f"{data['name']} failed with division edges",
+    )
 
     metric = TrackOverlapMetrics(include_division_edges=False)
     results = metric._compute(matched)
@@ -178,7 +190,12 @@ def test_track_overlap_metrics(data, inverse) -> None:
             "track_purity": expected["target_effectiveness"],
             "target_effectiveness": expected["track_purity"],
         }
-    assert results == expected, f"{data['name']} failed without division edges"
+        results.pop("track_fractions", None)
+    np.testing.assert_allclose(
+        list(results.values()),
+        list(expected.values()),
+        err_msg=f"{data['name']} failed without division edges",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Proposed Change
Closes #40

This PR adds an additional result to the `TrackOverlap` metrics representing track fractions (TF): the **unweighted** track effectiveness.

This is calculated as the average fraction of maximally overlapping predicted tracklets onto the GT tracklets. Unlike track effectiveness, this metric does not take into account the tracklet length when computing fractions.

Unlike track purity/track effectiveness, it's not trivial to "invert" the track fractions number, so I only test the "forward" direction in this case. I also got a couple of floating point errors in the tests, so I changed the assertion to `np.allclose`.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- New feature or enhancement

Which topics does your change affect? Delete those that do not apply.
- Metrics

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.