### PR TITLE
Ensure point loader always returns positive integer IDs

### DIFF
--- a/src/traccuracy/loaders/_point.py
+++ b/src/traccuracy/loaders/_point.py
@@ -33,8 +33,9 @@ def load_point_data(
             Defaults to None.
         parent_column (str | None, optional): A reference to the parent node in the previous
             time frame. Defaults to "parent".
-        id_column (str, optional): Optional column used to specify node ids.
-            Defaults to "node_id"
+        id_column (str, optional): Column used to specify node ids. Node IDs should
+            be unique positive integers.
+            Defaults to 'node_id'
         pos_columns (tuple[str], optional): A tuple of columns to use for position.
             Defaults to ("z", "y", "x").
         time_column (str, optional): The column to use for time. Defaults to "t".
@@ -47,6 +48,8 @@ def load_point_data(
         ValueError: Must provide either a path or a dataframe
         ValueError: parent_column not present in data
         ValueError: id_column not present in data
+        ValueError: id_column does not contain positive integers
+        ValueError: id_column does not contain unique values
         ValueError: pos_columns not present in data
         ValueError: time_column not present in data
         ValueError: seg_id_column not present in data
@@ -71,6 +74,12 @@ def load_point_data(
 
     if id_column not in df.columns:
         raise ValueError(f"Specified id_column {id_column} not present")
+
+    if not pd.api.types.is_integer_dtype(df[id_column]) or not np.all(df[id_column] >= 0):
+        raise ValueError(f"Specified id_column {id_column} must contain positive integers.")
+
+    if not len(df[id_column].unique()) == len(df[id_column]):
+        raise ValueError(f"Specified id_column {id_column} must contain unique values.")
 
     if not all(c in df.columns for c in pos_columns):
         raise ValueError(f"Specified pos_columns {pos_columns} not present")

--- a/tests/loaders/test_point.py
+++ b/tests/loaders/test_point.py
@@ -56,6 +56,27 @@ class Test_load_point_data:
         with pytest.raises(ValueError, match="Specified seg_id_column *"):
             load_point_data(df=pd.DataFrame(data), seg_id_column="seg_label")
 
+    def test_invalid_id_column(self):
+        nrows = 5
+        df = self.get_valid_df(nrows)
+        df["node_id"] = df["node_id"] - 10
+        with pytest.raises(
+            ValueError, match="Specified id_column node_id must contain positive integers"
+        ):
+            load_point_data(df=df, name="test")
+
+        df["node_id"] = df["node_id"] + 0.5
+        with pytest.raises(
+            ValueError, match="Specified id_column node_id must contain positive integers"
+        ):
+            load_point_data(df=df, name="test")
+
+        df["node_id"] = 2
+        with pytest.raises(
+            ValueError, match="Specified id_column node_id must contain unique values"
+        ):
+            load_point_data(df=df, name="test")
+
     def test_load_from_dataframe(self):
         # Make a valid dataframe using defaults
         nrows = 5


### PR DESCRIPTION
# Proposed Change

This PR updates the points loader to ensure that the returned graph contains positive integer node IDs.

We did look at potentially regenerating the node IDs if they do not match the requirements, but it would be a huge headache to do this and still keep correspondence with the parent IDs so we decided to simply error.

# Types of Changes
- Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Delete those that do not apply.
- Loaders

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.