### PR TITLE
Allow skip edge relaxation in track overlap metrics

### DIFF
--- a/src/traccuracy/metrics/_track_overlap.py
+++ b/src/traccuracy/metrics/_track_overlap.py
@@ -56,7 +56,7 @@ class TrackOverlapMetrics(Metric):
         if relax_skips_gt + relax_skips_pred == 1:
             warnings.warn(
                 "Relaxing skips for either predicted or ground truth graphs"
-                + "will still affect all overlap metrics.",
+                + " will still affect all overlap metrics.",
                 stacklevel=2,
             )
         relaxed = relax_skips_gt or relax_skips_pred
@@ -149,13 +149,14 @@ def _calc_overlap_score(
         # that overlap
         overlapping_id_to_count: dict[int, int] = defaultdict(lambda: 0)
         for ref_src, ref_tgt in reference_tracklet.edges():
-            # skip_counted = False
             if (ref_src, ref_tgt) in reference_skips:
                 # if this is a skip edge, there is some equivalent path in the overlaps
                 # let's find an edge on that path and update the count
-                edge_in_overlapping_path = next(iter(overlap_path_to_reference_skip_map.values()))[
-                    "edge_in_path"
-                ]
+                for node in overlap_path_to_reference_skip_map:
+                    path_info = overlap_path_to_reference_skip_map[node]
+                    if path_info["skip_edge"] == (ref_src, ref_tgt):
+                        edge_in_overlapping_path = path_info["edge_in_path"]
+                        break
                 overlapping_id_to_count[overlap_edge_to_tid[edge_in_overlapping_path]] += 1
                 continue
             # this edge is part of an equivalent path for an overlap skip edge

--- a/tests/metrics/test_track_overlap_metrics.py
+++ b/tests/metrics/test_track_overlap_metrics.py
@@ -123,48 +123,72 @@ class TestStandardOverlapMetrics:
     # ex_graphs.edge_one_to_two
 
     @pytest.mark.parametrize(
-        ("incl_div_edges", "tp", "te"), [(True, 1 / 3, 0.5), (False, 1 / 3, 0.5)]
+        ("incl_div_edges", "relax_edges", "tp", "te"),
+        [
+            (True, False, 1 / 3, 0.5),
+            (False, False, 1 / 3, 0.5),
+            (True, True, 1, 1),
+            (False, True, 1, 1),
+        ],
     )
-    def test_gap_close_gt_gap(self, incl_div_edges, tp, te):
+    def test_gap_close_gt_gap(self, incl_div_edges, relax_edges, tp, te):
         matched = ex_graphs.gap_close_gt_gap()
         metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
         assert results[self.tp] == tp
         assert results[self.te] == te
 
     @pytest.mark.parametrize(
-        ("incl_div_edges", "tp", "te"), [(True, 0.5, 1 / 3), (False, 0.5, 1 / 3)]
+        ("incl_div_edges", "relax_edges", "tp", "te"),
+        [
+            (True, False, 0.5, 1 / 3),
+            (False, False, 0.5, 1 / 3),
+            (True, True, 1, 1),
+            (False, True, 1, 1),
+        ],
     )
-    def test_gap_close_pred_gap(self, incl_div_edges, tp, te):
+    def test_gap_close_pred_gap(self, incl_div_edges, relax_edges, tp, te):
         matched = ex_graphs.gap_close_pred_gap()
         metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
-        assert results[self.tp] == tp
-        assert results[self.te] == te
-
-    @pytest.mark.parametrize(("incl_div_edges", "tp", "te"), [(True, 1, 1), (False, 1, 1)])
-    def test_gap_close_matched_gap(self, incl_div_edges, tp, te):
-        matched = ex_graphs.gap_close_matched_gap()
-        metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
-        assert results[self.tp] == tp
-        assert results[self.te] == te
-
-    @pytest.mark.parametrize(("incl_div_edges", "tp", "te"), [(True, 0, 0), (False, 0, 0)])
-    def test_gap_close_offset(self, incl_div_edges, tp, te):
-        matched = ex_graphs.gap_close_offset()
-        metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
         assert results[self.tp] == tp
         assert results[self.te] == te
 
     @pytest.mark.parametrize(
-        ("incl_div_edges", "tp", "te"), [(True, 1 / 7, 1 / 7), (False, 1 / 7, 1 / 7)]
+        ("incl_div_edges", "relax_edges", "tp", "te"),
+        [(True, False, 1, 1), (False, False, 1, 1), (True, True, 1, 1), (False, True, 1, 1)],
     )
-    def test_gap_all_basic_errors(self, incl_div_edges, tp, te):
+    def test_gap_close_matched_gap(self, incl_div_edges, relax_edges, tp, te):
+        matched = ex_graphs.gap_close_matched_gap()
+        metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
+        assert results[self.tp] == tp
+        assert results[self.te] == te
+
+    @pytest.mark.parametrize(
+        ("incl_div_edges", "relax_edges", "tp", "te"),
+        [(True, False, 0, 0), (False, False, 0, 0), (True, True, 0, 0), (False, True, 0, 0)],
+    )
+    def test_gap_close_offset(self, relax_edges, incl_div_edges, tp, te):
+        matched = ex_graphs.gap_close_offset()
+        metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
+        assert results[self.tp] == tp
+        assert results[self.te] == te
+
+    @pytest.mark.parametrize(
+        ("incl_div_edges", "relax_edges", "tp", "te"),
+        [
+            (True, False, 1 / 7, 1 / 7),
+            (False, False, 1 / 7, 1 / 7),
+            (True, True, 4 / 7, 4 / 7),
+            (False, True, 4 / 7, 4 / 7),
+        ],
+    )
+    def test_gap_all_basic_errors(self, incl_div_edges, relax_edges, tp, te):
         matched = ex_graphs.all_basic_errors()
         metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
         assert results[self.tp] == tp
         assert results[self.te] == te
 
@@ -249,30 +273,34 @@ class TestStandardOverlapMetrics:
         assert results[self.te] == te
 
     @pytest.mark.parametrize(
-        ("incl_div_edges", "tp", "te"),
+        ("incl_div_edges", "relax_edges", "tp", "te"),
         [
-            (True, 4 / 5, 4 / 6),
-            (False, 3 / 3, 3 / 4),
+            (True, False, 4 / 5, 4 / 6),
+            (False, False, 3 / 3, 3 / 4),
+            (True, True, 1, 1),
+            (False, True, 3 / 3, 3 / 4),
         ],
     )
-    def test_div_daughter_gap(self, incl_div_edges, tp, te):
+    def test_div_daughter_gap(self, incl_div_edges, relax_edges, tp, te):
         matched = ex_graphs.div_daughter_gap()
         metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
         assert results[self.tp] == tp
         assert results[self.te] == te
 
     @pytest.mark.parametrize(
-        ("incl_div_edges", "tp", "te"),
+        ("incl_div_edges", "relax_edges", "tp", "te"),
         [
-            (True, 2 / 4, 2 / 6),
-            (False, 2 / 2, 2 / 4),
+            (True, False, 2 / 4, 2 / 6),
+            (False, False, 2 / 2, 2 / 4),
+            (True, True, 1, 1),
+            (False, True, 1, 2 / 4),
         ],
     )
-    def test_div_daughter_dual_gap(self, incl_div_edges, tp, te):
+    def test_div_daughter_dual_gap(self, incl_div_edges, relax_edges, tp, te):
         matched = ex_graphs.div_daughter_dual_gap()
         metric = TrackOverlapMetrics(include_division_edges=incl_div_edges)
-        results = metric._compute(matched)
+        results = metric._compute(matched, relax_skips_gt=relax_edges, relax_skips_pred=relax_edges)
         assert results[self.tp] == tp
         assert results[self.te] == te
 


### PR DESCRIPTION
# Proposed Change

This PR implements skip edge relaxation for `Track Purity` and `Target Effectiveness` metrics. 

Relaxing **either GT or pred** skip edges results in both track purity and target effectiveness being affected.
"Offset" skip edges are still considered incorrect, even if there is a single path between some common predecessor and some 
 common successor of the skip edges.

All skip-edge-inclusive test cases are checked, but track fractions is still not checked.

# Types of Changes
- New feature or enhancement
- Documentation update

- Metrics

# Checklist
- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.