### PR TITLE
Raise error if only one graph has error annotations

### DIFF
--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING
 
 from tqdm import tqdm
@@ -34,8 +35,16 @@ def get_vertex_errors(matched_data: Matched) -> None:
     gt_graph = matched_data.gt_graph
     dict_mapping = matched_data.pred_gt_map
 
+    if comp_graph.node_errors + gt_graph.node_errors == 1:
+        graph_with_errors = "pred graph" if comp_graph.node_errors else "GT graph"
+        raise ValueError(
+            f"Only {graph_with_errors} has node errors annotated. "
+            "Please ensure either both or neither "
+            + "of the graphs have traccuracy annotations before running metrics."
+        )
+
     if comp_graph.node_errors and gt_graph.node_errors:
-        logger.info("Node errors already calculated. Skipping graph annotation")
+        warnings.warn("Node errors already calculated. Skipping graph annotation", stacklevel=2)
         return
 
     # will flip this when we come across the vertex in the mapping
@@ -69,13 +78,21 @@ def get_edge_errors(matched_data: Matched) -> None:
     gt_graph = matched_data.gt_graph
     node_mapping = matched_data.mapping
 
+    if comp_graph.edge_errors + gt_graph.edge_errors == 1:
+        graph_with_errors = "pred graph" if comp_graph.edge_errors else "GT graph"
+        raise ValueError(
+            f"Only {graph_with_errors} has edge errors annotated. "
+            "Please ensure either both or neither "
+            + "of the graphs have traccuracy annotations before running metrics."
+        )
+
     if comp_graph.edge_errors and gt_graph.edge_errors:
-        logger.info("Edge errors already calculated. Skipping graph annotation")
+        warnings.warn("Edge errors already calculated. Skipping graph annotation", stacklevel=2)
         return
 
     # Node errors must already be annotated
     if not comp_graph.node_errors and not gt_graph.node_errors:
-        logger.warning("Node errors have not been annotated. Running node annotation.")
+        logger.info("Node errors have not been annotated. Running node annotation.", stacklevel=2)
         get_vertex_errors(matched_data)
 
     comp_tp_nodes = comp_graph.get_nodes_with_flag(NodeFlag.CTC_TRUE_POS)

--- a/tests/metrics/test_basic.py
+++ b/tests/metrics/test_basic.py
@@ -67,7 +67,8 @@ class TestBasicMetrics:
         matched = ex_graphs.all_basic_errors()
         # Compute strict first to test for double counting
         resdict = self.m._compute(matched)
-        resdict = self.m._compute(matched, relax_skips_gt=True, relax_skips_pred=True)
+        with pytest.warns(UserWarning, match="already calculated"):
+            resdict = self.m._compute(matched, relax_skips_gt=True, relax_skips_pred=True)
 
         # Expected counts
         node_tp = 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -253,10 +253,11 @@ class Test_export_graphs_to_geff:
     def test_multiple_metrics(self, tmp_path):
         matched = larger_example_1()
         # Test results object and the dictionary
-        results = [
-            DivisionMetrics(max_frame_buffer=2).compute(matched),
-            BasicMetrics().compute(matched),
-        ]
+        with pytest.warns(UserWarning, match="already calculated"):
+            results = [
+                DivisionMetrics(max_frame_buffer=2).compute(matched),
+                BasicMetrics().compute(matched),
+            ]
         out_zarr = tmp_path / "test.zarr"
         export_graphs_to_geff(out_zarr, matched, results, target_frame_buffer=2)
 

--- a/tests/track_errors/test_basic.py
+++ b/tests/track_errors/test_basic.py
@@ -2,7 +2,23 @@ import pytest
 
 import tests.examples.graphs as ex_graphs
 from traccuracy._tracking_graph import EdgeFlag, NodeFlag
+from traccuracy.matchers._matched import Matched
 from traccuracy.track_errors._basic import _classify_edges, _classify_nodes
+
+
+def test_inconsistent_annotation_raises():
+    matched = ex_graphs.good_matched()
+    _classify_nodes(matched)
+    _classify_edges(matched)
+
+    gt_graph = matched.gt_graph
+    pred_graph = ex_graphs.good_matched().pred_graph
+    matched = Matched(gt_graph=gt_graph, pred_graph=pred_graph, mapping=[], matcher_info={})
+    with pytest.raises(ValueError, match="both or neither of the graphs"):
+        _classify_nodes(matched)
+
+    with pytest.raises(ValueError, match="both or neither of the graphs"):
+        _classify_edges(matched)
 
 
 class TestStandardNode:

--- a/tests/track_errors/test_basic.py
+++ b/tests/track_errors/test_basic.py
@@ -22,7 +22,7 @@ class TestStandardNode:
         for attrs in matched.gt_graph.nodes.values():
             assert NodeFlag.FALSE_NEG in attrs
 
-    def test_good_match(self, caplog):
+    def test_good_match(self):
         matched = ex_graphs.good_matched()
         _classify_nodes(matched)
 
@@ -32,8 +32,8 @@ class TestStandardNode:
                 assert NodeFlag.TRUE_POS in attrs
 
         # Check that it doesn't run a second time
-        _classify_nodes(matched)
-        assert "Node errors already calculated. Skipping graph annotation" in caplog.text
+        with pytest.warns(UserWarning, match="already calculated"):
+            _classify_nodes(matched)
 
     @pytest.mark.parametrize("t", [0, 1, 2])
     def test_fn_node(self, t):
@@ -141,8 +141,8 @@ class TestStandardEdge:
                 assert EdgeFlag.TRUE_POS in attrs
 
         # Check that it doesn't run a second time
-        _classify_edges(matched)
-        assert "Edge errors already calculated. Skipping graph annotation" in caplog.text
+        with pytest.warns(UserWarning, match="already calculated"):
+            _classify_edges(matched)
 
     def test_fn_node_end(self):
         matched = ex_graphs.fn_node_matched(0)
@@ -254,8 +254,8 @@ class TestGapCloseEdge:
         assert EdgeFlag.FALSE_POS in pred_graph.edges[(6, 7)]
 
         # Check that it doesn't run a second time
-        _classify_edges(matched, relax_skips_gt=True)
-        assert "Edge errors already calculated. Skipping graph annotation" in caplog.text
+        with pytest.warns(UserWarning, match="already calculated"):
+            _classify_edges(matched, relax_skips_gt=True)
 
     def test_fp_gap_close_edge(self, caplog):
         matched = ex_graphs.gap_close_pred_gap()
@@ -281,8 +281,8 @@ class TestGapCloseEdge:
         assert EdgeFlag.FALSE_NEG in gt_graph.edges[(3, 4)]
 
         # Check that it doesn't run a second time
-        _classify_edges(matched, relax_skips_pred=True)
-        assert "Edge errors already calculated. Skipping graph annotation" in caplog.text
+        with pytest.warns(UserWarning, match="already calculated"):
+            _classify_edges(matched, relax_skips_pred=True)
 
     def test_good_gap_close_edge(self):
         matched = ex_graphs.gap_close_matched_gap()

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -8,6 +8,21 @@ from traccuracy.matchers._matched import Matched
 from traccuracy.track_errors._ctc import get_edge_errors, get_vertex_errors
 
 
+def test_inconsistent_annotations_raises():
+    matched = ex_graphs.good_matched()
+    get_vertex_errors(matched)
+    get_edge_errors(matched)
+
+    gt_graph = matched.gt_graph
+    pred_graph = ex_graphs.good_matched().pred_graph
+    matched = Matched(gt_graph=gt_graph, pred_graph=pred_graph, mapping=[], matcher_info={})
+    with pytest.raises(ValueError, match="both or neither of the graphs"):
+        get_vertex_errors(matched)
+
+    with pytest.raises(ValueError, match="both or neither of the graphs"):
+        get_edge_errors(matched)
+
+
 class TestStandardNode:
     def test_no_gt(self):
         matched = ex_graphs.empty_gt()

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -144,6 +144,7 @@ class Test_get_succ_by_t:
 class TestStandardShifted:
     """Test correct_shifted_divisions against standard shifted cases"""
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize("n_frames", [1, 2])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",
@@ -164,6 +165,7 @@ class TestStandardShifted:
 
         assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",
@@ -188,6 +190,7 @@ class TestStandardShifted:
 
             assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize("n_frames", [1, 2])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",
@@ -208,6 +211,7 @@ class TestStandardShifted:
 
         assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
 
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -39,6 +39,17 @@ def swap_gt_pred(matched: Matched):
     )
 
 
+def test_inconsistent_annotations_raises():
+    matched = ex_graphs.good_matched()
+    _classify_divisions(matched)
+
+    gt_graph = matched.gt_graph
+    pred_graph = ex_graphs.good_matched().pred_graph
+    matched = Matched(gt_graph=gt_graph, pred_graph=pred_graph, mapping=[], matcher_info={})
+    with pytest.raises(ValueError, match="both or neither of the graphs"):
+        _classify_divisions(matched)
+
+
 class TestStandardsDivisions:
     """Test _classify_divisions against standard cases
 


### PR DESCRIPTION
# Proposed Change

This PR checks that error classification functions are being called with either both graphs having error annotations, or neither graph having error annotations. This ensures a user cannot end up with inconsistent annotations on graphs by accidentally re-running classification on a graph that already has errors annotated e.g. by keeping GT the same and only changing pred.

In future we may want to add a utility that "cleans" an annotated graph so that a user can reuse the graph without requiring a copy.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)

Which topics does your change affect? Delete those that do not apply.
- Track Errors

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.