### PR TITLE
Validate that TrackingGraph edges go forward in time

### DIFF
--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -286,6 +286,8 @@ class TrackingGraph:
 
         # store edge id in edges_by_flag
         for edge, attrs in self.graph.edges.items():
+            if validate:
+                self._validate_edge(edge)
             for edge_flag in EdgeFlag:
                 if attrs.get(edge_flag.value):
                     self.edges_by_flag[edge_flag.value].add(edge)
@@ -396,6 +398,29 @@ class TrackingGraph:
         # Node ids must be positive integers
         assert np.issubdtype(type(node), np.integer), f"Node id of node {node} is not an integer"
         assert node >= 0, f"Node id of node {node} is not positive"
+
+    def _validate_edge(self, edge: tuple[Hashable, Hashable]) -> None:
+        """Check that an edge goes strictly forward in time.
+
+        TrackingGraph represents a tracking solution whose edges go forward in
+        time, so every edge (src, dst) must satisfy frame[dst] > frame[src].
+        This rules out self-loops (frame[dst] == frame[src]) and, because the
+        frame strictly increases along every edge, guarantees the graph is
+        acyclic. Skip edges (spanning more than one frame) still go forward and
+        are allowed.
+
+        Args:
+            edge (tuple): The (source, target) node ids of the edge.
+        """
+        src, dst = edge
+        src_frame = self.graph.nodes[src][self.frame_key]
+        dst_frame = self.graph.nodes[dst][self.frame_key]
+        assert dst_frame > src_frame, (
+            f"Edge {edge} does not go forward in time: source node {src} is at "
+            f"frame {src_frame} but target node {dst} is at frame {dst_frame}. "
+            "TrackingGraph edges must go strictly forward in time (no "
+            "self-loops or cycles)."
+        )
 
     @property
     def nodes(self) -> NodeView:

--- a/tests/loaders/test_ctc.py
+++ b/tests/loaders/test_ctc.py
@@ -65,7 +65,7 @@ def test_ctc_single_nodes():
         {"Cell_ID": 2, "Start": 0, "End": 2, "Parent_ID": 0},
         {"Cell_ID": 3, "Start": 3, "End": 3, "Parent_ID": 2},
         {"Cell_ID": 4, "Start": 3, "End": 3, "Parent_ID": 2},
-        {"Cell_ID": 5, "Start": 3, "End": 3, "Parent_ID": 4},
+        {"Cell_ID": 5, "Start": 4, "End": 4, "Parent_ID": 4},
     ]
 
     detections = [
@@ -78,7 +78,7 @@ def test_ctc_single_nodes():
         {"segmentation_id": 2, "x": 2, "y": 1, "z": 1, "t": 2},
         {"segmentation_id": 3, "x": 1, "y": 1, "z": 1, "t": 3},
         {"segmentation_id": 4, "x": 1, "y": 2, "z": 2, "t": 3},
-        {"segmentation_id": 5, "x": 1, "y": 1, "z": 2, "t": 3},
+        {"segmentation_id": 5, "x": 1, "y": 1, "z": 2, "t": 4},
     ]
     df = pd.DataFrame(data)
     G = _ctc.ctc_to_graph(df, pd.DataFrame.from_records(detections))

--- a/tests/loaders/test_geff.py
+++ b/tests/loaders/test_geff.py
@@ -19,7 +19,15 @@ class Test_load_geff_data:
     def test_simple_2d(self, tmp_path):
         zarr_path = tmp_path / "test.zarr"
         store, _ = create_simple_2d_geff(directed=True)
-        self.geff_to_disk(store, zarr_path)
+        # The synthetic geff sample places multiple nodes in the same frame,
+        # which isn't a valid forward-in-time tracking graph. Reassign a unique
+        # increasing time per node id (all sample edges go low->high id) so the
+        # loaded graph respects the TrackingGraph forward-in-time contract.
+        graph, meta = read(store, backend="networkx")
+        time_key = next(ax.name for ax in meta.axes if ax.type == "time")
+        for node in graph.nodes:
+            graph.nodes[node][time_key] = float(node)
+        write(graph, zarr_path, meta)
         tg = load_geff_data(zarr_path)
         assert len(tg.get_location(0)) == 2
 

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -91,9 +91,9 @@ def nx_comp1_pos_list():
     ]
 
     edges = [
-        {"source": 1, "target": 3, "tp": True},
-        {"source": 3, "target": 5, "tp": False},
-        {"source": 3, "target": 3},
+        {"source": 1, "target": 2, "tp": True},
+        {"source": 2, "target": 5, "tp": False},
+        {"source": 2, "target": 3},
         {"source": 3, "target": 4},
     ]
     graph = nx.DiGraph()
@@ -294,6 +294,55 @@ def test_validate_node():
     tg = TrackingGraph(nx.DiGraph(), segmentation=np.zeros((5, 5), dtype="int"))
     with pytest.raises(AssertionError, match=r"Segmentation label key .* not present for node .*"):
         tg._validate_node(node, attrs)
+
+
+def _graph_with_edges(nodes, edges):
+    """Build a DiGraph from {id: t} nodes and a list of (src, dst) edges."""
+    g = nx.DiGraph()
+    g.add_nodes_from([(nid, {"t": t, "y": 0, "x": 0}) for nid, t in nodes.items()])
+    g.add_edges_from(edges)
+    return g
+
+
+def test_validate_edge_self_loop_raises():
+    g = _graph_with_edges({1: 0}, [(1, 1)])
+    with pytest.raises(AssertionError, match=r"does not go forward in time"):
+        TrackingGraph(g, location_keys=("y", "x"))
+
+
+def test_validate_edge_backward_raises():
+    # Edge from a later frame to an earlier one.
+    g = _graph_with_edges({1: 0, 2: 1}, [(2, 1)])
+    with pytest.raises(AssertionError, match=r"does not go forward in time"):
+        TrackingGraph(g, location_keys=("y", "x"))
+
+
+def test_validate_edge_same_frame_raises():
+    # Both endpoints in the same frame (e.g. a merge/link within a frame).
+    g = _graph_with_edges({1: 0, 2: 0}, [(1, 2)])
+    with pytest.raises(AssertionError, match=r"does not go forward in time"):
+        TrackingGraph(g, location_keys=("y", "x"))
+
+
+def test_validate_edge_forward_and_skip_edges_pass():
+    # Consecutive-frame edge and a skip edge (spanning 2 frames) both allowed.
+    g = _graph_with_edges({1: 0, 2: 1, 3: 3}, [(1, 2), (2, 3)])
+    tg = TrackingGraph(g, location_keys=("y", "x"))
+    assert tg.graph.number_of_edges() == 2
+
+
+def test_validate_edge_merge_passes():
+    # Two parents in frame 0 merge into one child in frame 1 (in-degree 2).
+    g = _graph_with_edges({1: 0, 2: 0, 3: 1}, [(1, 3), (2, 3)])
+    tg = TrackingGraph(g, location_keys=("y", "x"))
+    assert tg.graph.in_degree(3) == 2
+
+
+def test_validate_edge_skipped_when_validate_false():
+    # validate=False bypasses edge validation, mirroring node validation.
+    g = _graph_with_edges({1: 0}, [(1, 1)])  # self-loop
+    tg = TrackingGraph(g, location_keys=("y", "x"), validate=False)
+    assert tg.graph.number_of_edges() == 1
 
 
 def test_get_cells_by_frame(simple_graph):

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -236,9 +236,14 @@ def test_assign_edge_errors():
     comp_g.add_nodes_from(comp_ids)
     comp_g.add_edges_from(comp_edges)
     nx.set_node_attributes(comp_g, True, NodeFlag.CTC_TRUE_POS)
+    # Edge sources sit in frame 0, targets in frame 1 (edges go forward in time).
+    comp_targets = {dst for _, dst in comp_edges}
     nx.set_node_attributes(
         comp_g,
-        {idx: {"t": 0, "segmentation_id": 1, "y": 0, "x": 0} for idx in comp_ids},
+        {
+            idx: {"t": 1 if idx in comp_targets else 0, "segmentation_id": 1, "y": 0, "x": 0}
+            for idx in comp_ids
+        },
     )
     G_comp = TrackingGraph(comp_g)
 
@@ -247,8 +252,13 @@ def test_assign_edge_errors():
     gt_g.add_nodes_from(gt_ids)
     gt_g.add_edges_from(gt_edges)
     nx.set_node_attributes(gt_g, False, NodeFlag.CTC_FALSE_NEG)
+    gt_targets = {dst for _, dst in gt_edges}
     nx.set_node_attributes(
-        gt_g, {idx: {"t": 0, "segmentation_id": 1, "y": 0, "x": 0} for idx in gt_ids}
+        gt_g,
+        {
+            idx: {"t": 1 if idx in gt_targets else 0, "segmentation_id": 1, "y": 0, "x": 0}
+            for idx in gt_ids
+        },
     )
     G_gt = TrackingGraph(gt_g)
 


### PR DESCRIPTION
## Summary

`TrackingGraph` is documented as "a directed graph representing a tracking solution where edges go forward in time," but nothing enforced it. Self-loops, same-frame edges, and cycles all passed through construction silently — even though downstream code assumes strictly forward edges (`is_skip_edge` computes `frame[src] + 1 != frame[dst]`, the complete-tracks metric computes `target_frame - source_frame` expecting a positive span, and the matchers rely on the DAG/forward structure).

This came up while reviewing the napari loader (#358): a self-parent entry `{1: [1]}` would build a 2-cycle that no layer caught. Rather than special-case it in one loader, this enforces the invariant centrally where it belongs.

## Change

Adds `TrackingGraph._validate_edge`, called per edge in `_set_attrs` under the existing `validate` flag. Every edge `(src, dst)` must satisfy `frame[dst] > frame[src]`. This:

- rejects **self-loops** (`frame[dst] == frame[src]`),
- rejects **backward** and **same-frame** edges,
- **guarantees acyclicity** — since the frame strictly increases along every edge, no cycle can exist,
- still **allows skip edges** (spanning more than one frame — they go forward),
- and is **bypassed by `validate=False`**, consistent with the existing node validation. (`clear_annotations()` already calls `_set_attrs(validate=False)`, so it's unaffected.)

Uses `assert` to match the style of the sibling `_validate_node` rather than mixing in a `ValueError`.

## Fixture fixes

Four pre-existing tests built degenerate graphs with same-frame edges that only worked because nothing validated them. I verified each is accidental (not testing same-frame behavior) and that no production code path legitimately produces such edges — the CTC public loader, for instance, already rejects a daughter that starts before its parent ends:

- **`nx_comp1_pos_list`** — its edge list was a copy-paste error vs. the sibling `nx_comp1` (a self-loop `(3,3)` and same-frame `(3,5)`); restored to the intended edges.
- **`test_ctc_single_nodes`** — a daughter tracklet started in its parent's final frame (invalid CTC); moved it one frame later.
- **`test_assign_edge_errors`** — all nodes were at `t=0`; edge sources now sit in frame 0, targets in frame 1.
- **`test_simple_2d` (geff)** — the synthetic geff sample graph is non-temporal (paired nodes share a frame); reassigns a unique increasing time per node so the loaded graph is forward-in-time.

## Testing

- 6 new tests: self-loop / backward / same-frame all raise; forward + skip edges pass; merge (in-degree 2) passes; `validate=False` bypasses.
- Full suite: 661 passed, no regressions. ruff / ruff-format / mypy / typos clean.

Independent design review by Codex confirmed the acyclicity argument, the skip-edge compatibility, and the `assert`-over-`ValueError` consistency call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
