### PR TITLE
Fix geff label_prop deprecation warning breaking CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyarrow",
     "scipy",
     "skan>=0.13",
-    "geff>=1.0",
+    "geff>=1.3.0.1.2",
     "pylapy[sparse]>=1.0"
 ]
 

--- a/src/traccuracy/loaders/_geff.py
+++ b/src/traccuracy/loaders/_geff.py
@@ -91,7 +91,7 @@ def load_geff_data(
         for rel_obj in meta.related_objects:
             if rel_obj.type == "labels":
                 rel_obj_path = os.path.join(geff_path, rel_obj.path)
-                label_key = rel_obj.label_prop
+                label_key = rel_obj.node_prop
 
         if rel_obj_path is None:
             raise ValueError('Did not find related_object of type "labels" in geff related objects')

--- a/tests/loaders/test_geff.py
+++ b/tests/loaders/test_geff.py
@@ -146,6 +146,7 @@ class Test_load_geff_data:
             load_geff_data(geff_path, seg_path=seg_path / seg_group, seg_property=seg_prop)
 
     def test_load_rel_obj(self, tmp_path):
+        """Load segmentation via related_objects using the current ``node_prop`` field."""
         zarr_path = tmp_path / "test.zarr"
         geff_path = zarr_path / "tracks"
         seg_group = "seg"
@@ -159,7 +160,7 @@ class Test_load_geff_data:
         )
         graph, meta = read(geff_store, backend="networkx")
         meta.related_objects = [
-            {"type": "labels", "path": f"../{seg_group}", "label_prop": seg_prop}
+            {"type": "labels", "path": f"../{seg_group}", "node_prop": seg_prop}
         ]
         write(graph=graph, metadata=meta, store=geff_path)
 


### PR DESCRIPTION
## Problem

CI is red on main (`fbbc6a6`) — all 12 test jobs fail on `test_load_rel_obj`:

```
FAILED tests/loaders/test_geff.py::Test_load_geff_data::test_load_rel_obj
  DeprecationWarning: `label_prop` was deprecated in geff-spec v1.2.1 in favor of `node_prop`
```

`geff-spec` 1.2.0 deprecated `RelatedObject.label_prop` in favor of `node_prop`. Since `pyproject.toml` has `filterwarnings = ["error"]`, the `DeprecationWarning` becomes a test error.

## Fix

- **Loader** (`_geff.py`): use `rel_obj.node_prop` instead of the deprecated `label_prop`.
- **Test** (`test_geff.py`): update `test_load_rel_obj` to use `node_prop`.
- **Dependency** (`pyproject.toml`): pin `geff>=1.3.0.1.2` (first release with geff-spec 1.2.0, which provides `node_prop`).

## Verification

All 10 geff loader tests pass locally (659 passed overall; 2 pre-existing errors from missing sample data / timeout, unrelated).