### PR TITLE
Classify sparse-ground-truth validity per result key, not per metric

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
@@ -13,6 +13,8 @@ Put an x in the boxes that apply. You can also fill these out after creating the
 - [ ] I have added benchmarking functions for my change `tests/bench.py`.
 - [ ] I have added a page to the documentation with a complete description of my matcher/metric including any references.
 - [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
+- [ ] For a new metric, I have specified `sparse_safe_keys`, `agnostic_keys` and `_sparse_inflatable_substrings` in the Metric definition.
+- [ ] For a new metric, I have added it to `ALL_METRIC_CLASSES` in tests/metrics/test_sparse_safe_keys.py
 
 # Further Comments
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
@@ -14,7 +14,7 @@ Put an x in the boxes that apply. You can also fill these out after creating the
 - [ ] I have added a page to the documentation with a complete description of my matcher/metric including any references.
 - [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
 - [ ] For a new metric, I have specified `sparse_safe_keys`, `agnostic_keys` and `_sparse_inflatable_substrings` in the Metric definition.
-- [ ] For a new metric, I have added it to `ALL_METRIC_CLASSES` in tests/metrics/test_sparse_safe_keys.py
+- [ ] For a new metric, I have added a `DECLARED_KEY_CASES` entry in tests/metrics/test_sparse_safe_keys.py, or listed it in `KEYLESS_METRICS` there if it has no sparse-safe or agnostic keys
 
 # Further Comments
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -36,6 +36,10 @@ Each `Metric` classifies every key in the dictionary it returns, via `Metric._cl
 - **agnostic**: a raw count or other value that is not itself a quality judgment (e.g. `Total GT Nodes`). Accurate regardless of annotation density, so no claim is made either way.
 - **dense-only** (the default for any key not listed above): counts or derives from unmatched predictions (false positives, precision, F1, ...) and will over-penalize correct predictions of unannotated ground truth.
 
+:::{warning}
+Although we classify certain metrics as `sparse-safe`, this does not mean that they, in isolation, provide meaningful insight into the true overall accuracy of the solution. One can trivially imagine, for example, a solution with an overwhelming number of annotations that achieves perfect node recall. These `sparse-safe` metrics also provide no insight on the quality or diversity of the ground truth annotations present. We advise extreme caution in interpreting or reporting these metrics.
+:::
+
 Sparseness is a property of the annotations rather than a per-run choice, so it is declared on
 the ground truth graph itself and is read-only after construction. Pass `is_sparse_gt=True` to
 {class}`~traccuracy.TrackingGraph` or to any loader (`load_ctc_data`, `load_geff_data`,

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -14,8 +14,8 @@ they can accept, and a brief description of behavior and any hyperparameters.
 
 Many metrics support relaxing skip edges for the ground truth and/or the prediction. Relaxing a skip edge means allowing one edge that spans multiple frames to match multiple edges in the other graph, thus potentially reducing the number of errors.
 
- Metric category | Matching Type(s) | Description |
-------------------|------------------|-------------
+| Metric category | Matching Type(s) | Description |
+|------------------|------------------|-------------|
 | [Basic Metrics](basic-metrics): TP, FP, and FN nodes and edges | `one-to-one`  | Counts the number of **true positive** (matched) nodes and edges, **false positive** (unmatched in the prediction) nodes and edges, and **false negative** (unmatched in the ground truth) nodes and edges. |
 | [Division metrics](division-metrics): TP, FP, and FN divisions and F1 score/Branching Correctness (BC) | `one-to-one` | Counts the number of **true positive** (matched) divisions, **false positive** (unmatched in the prediction) divisions, and **false negative** (unmatched in the ground truth) divisions. Then computes the division **F1-Score**, also called **Branching Correctness** by the CTC-Bio metrics. Has a `max_frame_buffer` parameter that allows counting divisions as correct within `max_frame_buffer` frames as long as the parent and children match within the buffer| 
 | [CTC Metrics](ctc-metrics): DET, LNK, TRA | `one-to-one`, `many-to-one` | A set of three metrics between 0 and 1, with higher scores indicating better performance. DET measures node errors, LNK measures linking errors, and TRA combines detection and linking errors. |
@@ -36,9 +36,25 @@ Each `Metric` classifies every key in the dictionary it returns, via `Metric._cl
 - **agnostic**: a raw count or other value that is not itself a quality judgment (e.g. `Total GT Nodes`). Accurate regardless of annotation density, so no claim is made either way.
 - **dense-only** (the default for any key not listed above): counts or derives from unmatched predictions (false positives, precision, F1, ...) and will over-penalize correct predictions of unannotated ground truth.
 
+Sparseness is a property of the annotations rather than a per-run choice, so it is declared on
+the ground truth graph itself and is read-only after construction. Pass `is_sparse_gt=True` to
+{class}`~traccuracy.TrackingGraph` or to any loader (`load_ctc_data`, `load_geff_data`,
+`load_napari_data`, `load_point_data`), and every metric computed against that graph
+restricts itself to sparse-safe and agnostic keys:
+
+```python
+gt = load_ctc_data("path/to/gt", is_sparse_gt=True)
+```
+
 :::{note}
-`Metric.compute` has a `sparse_safe` option which can be set to True in order to return only sparse safe results.
+`Metric.compute` also takes a `sparse_only` option, for filtering against a graph that was not
+marked sparse at construction. A graph marked `is_sparse_gt=True` always filters, regardless of
+this option.
 :::
+
+A metric that declares no sparse-safe or agnostic keys at all (CCA, CHOTA) cannot report
+anything under sparse ground truth. Those are skipped with a warning rather than computed and
+discarded.
 
 Sparse-safe and agnostic keys by metric (everything else that metric returns is dense-only):
 
@@ -46,7 +62,7 @@ Sparse-safe and agnostic keys by metric (everything else that metric returns is 
 |---|---|---|
 | [Basic Metrics](basic-metrics) | `True/False Negative {Nodes,Edges}`, `{Node,Edge} Recall`, `Skip GT/Pred True Positive Edges`, `Skip False Negative Edges` | `Total GT/Pred {Nodes,Edges}` |
 | [Division metrics](division-metrics) | `Division Recall`, `True/False Negative Divisions`, `Wrong Children Divisions`, `True Positive Skip Divisions` | `Total GT Divisions`, `Total Predicted Divisions` |
-| [CTC Metrics](ctc-metrics) | none | none |
+| [CTC Metrics](ctc-metrics) | `fn_nodes`, `fn_edges` | none |
 | [Cell Cycle Accuracy (CCA)](cca) | none | none |
 | [Complete Tracklets and Lineages](complete-tracks) | `correct_lineages`, `correct_tracklets`, `complete_lineages`, `complete_tracklets` | `total_lineages`, `total_tracklets` |
 | [Track Overlap Metrics](track-overlap-metrics) | `target_effectiveness`, `track_fractions` | none |

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -32,7 +32,7 @@ Most metrics assume **dense** ground truth (every real cell is annotated), so a 
 
 Each `Metric` classifies every key in the dictionary it returns, via `Metric._classify_sparse_safe(key)` (also surfaced as `sparse_safe_keys`/`agnostic_keys` on {class}`~traccuracy.metrics.Results`'s `metric` info). Many metrics mix categories: for example {class}`~traccuracy.metrics.DivisionMetrics` reports both a sparse-safe recall and a dense-only precision from the same call. The three categories are:
 
-- **sparse-safe**: judges only structure the annotation can judge (matches, ground-truth-only counts, false negatives). Valid on both sparse and dense ground truth.
+- **sparse-safe**: a quality/error assessment that does not assume predictions with no match are false positives so it remains valid when ground truth is sparse.
 - **agnostic**: a raw count or other value that is not itself a quality judgment (e.g. `Total GT Nodes`). Accurate regardless of annotation density, so no claim is made either way.
 - **dense-only** (the default for any key not listed above): counts or derives from unmatched predictions (false positives, precision, F1, ...) and will over-penalize correct predictions of unannotated ground truth.
 

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -14,9 +14,33 @@ they can accept, and a brief description of behavior and any hyperparameters.
 
 Many metrics support relaxing skip edges for the ground truth and/or the prediction. Relaxing a skip edge means allowing one edge that spans multiple frames to match multiple edges in the other graph, thus potentially reducing the number of errors.
 
-:::{warning}
-Unless otherwise noted, metrics are written assuming that you have dense ground truth annotations. The results on sparse annotations may be unpredictable and should be interpreted cautiously.
+(sparse-annotations)=
+## Dense vs. sparse ground truth
+
+Most metrics assume **dense** ground truth (every real cell is annotated), so a predicted node, edge, or division with no ground truth match is a false positive. On **sparse** ground truth, where only a subset of cells are annotated, that would over-penalize correct predictions of unannotated cells.
+
+Each `Metric` classifies every key in the dictionary it returns, via `Metric._classify_sparse_safe(key)` (also surfaced as `sparse_safe_keys`/`agnostic_keys` on {class}`~traccuracy.metrics.Results`'s `metric` info). Many metrics mix categories: for example {class}`~traccuracy.metrics.DivisionMetrics` reports both a sparse-safe recall and a dense-only precision from the same call. The three categories are:
+
+- **sparse-safe**: judges only structure the annotation can judge (matches, ground-truth-only counts, false negatives). Valid on both sparse and dense ground truth.
+- **agnostic**: a raw count or other value that is not itself a quality judgment (e.g. `Total GT Nodes`). Accurate regardless of annotation density, so no claim is made either way.
+- **dense-only** (the default for any key not listed above): counts or derives from unmatched predictions (false positives, precision, F1, ...) and will over-penalize correct predictions of unannotated ground truth.
+
+:::{note}
+`Metric.compute` has a `sparse_safe` option which can be set to True in order to return only sparse safe results.
 :::
+
+Sparse-safe and agnostic keys by metric (everything else that metric returns is dense-only):
+
+| Metric | Sparse-safe keys | Agnostic keys |
+|---|---|---|
+| [Basic Metrics](basic-metrics) | `True/False Negative {Nodes,Edges}`, `{Node,Edge} Recall`, `Skip GT/Pred True Positive Edges`, `Skip False Negative Edges` | `Total GT/Pred {Nodes,Edges}` |
+| [Division metrics](division-metrics) | `Division Recall`, `True/False Negative Divisions`, `Wrong Children Divisions`, `True Positive Skip Divisions` | `Total GT Divisions`, `Total Predicted Divisions` |
+| [CTC Metrics](ctc-metrics) | none | none |
+| [Cell Cycle Accuracy (CCA)](cca) | none | none |
+| [Complete Tracklets and Lineages](complete-tracks) | `correct_lineages`, `correct_tracklets`, `complete_lineages`, `complete_tracklets` | `total_lineages`, `total_tracklets` |
+| [Track Overlap Metrics](track-overlap-metrics) | `target_effectiveness`, `track_fractions` | none |
+| [Complete Tracks by Length](complete-tracks-by-length-metric) | `correct`, `accuracy` | `total` |
+| [Cell-specific Higher Order Tracking Accuracy (CHOTA)](chota-metric) | none | none |
 
 | Metric category | Matching Type(s) | Description |
 ------------------|------------------|-------------

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -47,9 +47,7 @@ gt = load_ctc_data("path/to/gt", is_sparse_gt=True)
 ```
 
 :::{note}
-`Metric.compute` also takes a `sparse_only` option, for filtering against a graph that was not
-marked sparse at construction. A graph marked `is_sparse_gt=True` always filters, regardless of
-this option.
+Metrics computed on a graph that is marked as `is_sparse_gt=True` at creation will always use the `sparse_only=True` option. However sparse mode can always be enabled by manually setting the `sparse_only=True` flag when calling `Metric.compute`.
 :::
 
 A metric that declares no sparse-safe or agnostic keys at all (CCA, CHOTA) cannot report

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -14,6 +14,17 @@ they can accept, and a brief description of behavior and any hyperparameters.
 
 Many metrics support relaxing skip edges for the ground truth and/or the prediction. Relaxing a skip edge means allowing one edge that spans multiple frames to match multiple edges in the other graph, thus potentially reducing the number of errors.
 
+ Metric category | Matching Type(s) | Description |
+------------------|------------------|-------------
+| [Basic Metrics](basic-metrics): TP, FP, and FN nodes and edges | `one-to-one`  | Counts the number of **true positive** (matched) nodes and edges, **false positive** (unmatched in the prediction) nodes and edges, and **false negative** (unmatched in the ground truth) nodes and edges. |
+| [Division metrics](division-metrics): TP, FP, and FN divisions and F1 score/Branching Correctness (BC) | `one-to-one` | Counts the number of **true positive** (matched) divisions, **false positive** (unmatched in the prediction) divisions, and **false negative** (unmatched in the ground truth) divisions. Then computes the division **F1-Score**, also called **Branching Correctness** by the CTC-Bio metrics. Has a `max_frame_buffer` parameter that allows counting divisions as correct within `max_frame_buffer` frames as long as the parent and children match within the buffer| 
+| [CTC Metrics](ctc-metrics): DET, LNK, TRA | `one-to-one`, `many-to-one` | A set of three metrics between 0 and 1, with higher scores indicating better performance. DET measures node errors, LNK measures linking errors, and TRA combines detection and linking errors. |
+| [Cell Cycle Accuracy (CCA)](cca)| `one-to-one`, `many-to-one`| One of the CTC-Bio metrics. Measures the ability of a method to identify a distribution of cell cycle lengths that matches the distribution present in the ground truth.|
+| [Complete Tracklets and Lineages](complete-tracks) |  `one-to-one`, `many-to-one`| Extends the "Complete Tracks" from the CTC-Bio metrics. Measures the fraction of tracklets and lineages that are fully correct in the prediction.|
+| [Track Overlap Metrics](track-overlap-metrics): Track Purity (TP), Target Effectiveness (TE), Track Fractions (TF) | `one-to-one`, `many-to-one` , `one-to-many`| A set of metrics that compute the maximum overlap for each track, where track is defined as the region between divisions. Target effectiveness (TE) measures how much of each ground truth track is covered by the most overlapping predicted track, weighted by track length. Track Purity (TP) is the inverse of TE, and Track Fractions (TF) is the unwighted average of TE. |
+| [Complete Tracks by Length](complete-tracks-by-length-metric) | `one-to-one`, `many-to-one` | Generalizes [Complete Tracks](complete-tracks) to every track length: the accuracy (fraction fully correct) of tracklets or lineages that span N frames, for each length N. |
+| [Cell-specific Higher Order Tracking Accuracy (CHOTA)](chota-metric) |`one-to-one`, `many-to-one`, `one-to-many`, `many-to-many` | A metric between 0 and 1 that unifies local correctness, global coherence, and lineage tracking. Higher scores are better.| 
+
 (sparse-annotations)=
 ## Dense vs. sparse ground truth
 
@@ -41,14 +52,3 @@ Sparse-safe and agnostic keys by metric (everything else that metric returns is 
 | [Track Overlap Metrics](track-overlap-metrics) | `target_effectiveness`, `track_fractions` | none |
 | [Complete Tracks by Length](complete-tracks-by-length-metric) | `correct`, `accuracy` | `total` |
 | [Cell-specific Higher Order Tracking Accuracy (CHOTA)](chota-metric) | none | none |
-
-| Metric category | Matching Type(s) | Description |
-------------------|------------------|-------------
-| [Basic Metrics](basic-metrics): TP, FP, and FN nodes and edges | `one-to-one`  | Counts the number of **true positive** (matched) nodes and edges, **false positive** (unmatched in the prediction) nodes and edges, and **false negative** (unmatched in the ground truth) nodes and edges. |
-| [Division metrics](division-metrics): TP, FP, and FN divisions and F1 score/Branching Correctness (BC) | `one-to-one` | Counts the number of **true positive** (matched) divisions, **false positive** (unmatched in the prediction) divisions, and **false negative** (unmatched in the ground truth) divisions. Then computes the division **F1-Score**, also called **Branching Correctness** by the CTC-Bio metrics. Has a `max_frame_buffer` parameter that allows counting divisions as correct within `max_frame_buffer` frames as long as the parent and children match within the buffer| 
-| [CTC Metrics](ctc-metrics): DET, LNK, TRA | `one-to-one`, `many-to-one` | A set of three metrics between 0 and 1, with higher scores indicating better performance. DET measures node errors, LNK measures linking errors, and TRA combines detection and linking errors. |
-| [Cell Cycle Accuracy (CCA)](cca)| `one-to-one`, `many-to-one`| One of the CTC-Bio metrics. Measures the ability of a method to identify a distribution of cell cycle lengths that matches the distribution present in the ground truth.|
-| [Complete Tracklets and Lineages](complete-tracks) |  `one-to-one`, `many-to-one`| Extends the "Complete Tracks" from the CTC-Bio metrics. Measures the fraction of tracklets and lineages that are fully correct in the prediction.|
-| [Track Overlap Metrics](track-overlap-metrics): Track Purity (TP), Target Effectiveness (TE), Track Fractions (TF) | `one-to-one`, `many-to-one` , `one-to-many`| A set of metrics that compute the maximum overlap for each track, where track is defined as the region between divisions. Target effectiveness (TE) measures how much of each ground truth track is covered by the most overlapping predicted track, weighted by track length. Track Purity (TP) is the inverse of TE, and Track Fractions (TF) is the unwighted average of TE. |
-| [Complete Tracks by Length](complete-tracks-by-length-metric) | `one-to-one`, `many-to-one` | Generalizes [Complete Tracks](complete-tracks) to every track length: the accuracy (fraction fully correct) of tracklets or lineages that span N frames, for each length N. |
-| [Cell-specific Higher Order Tracking Accuracy (CHOTA)](chota-metric) |`one-to-one`, `many-to-one`, `one-to-many`, `many-to-many` | A metric between 0 and 1 that unifies local correctness, global coherence, and lineage tracking. Higher scores are better.| 

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -200,8 +200,11 @@ class TrackingGraph:
                 ``segmentation`` and ``location_keys`` (as a tuple) to be provided.
                 Defaults to None (no filtering).
             is_sparse_gt (bool, optional): If set to True, denotes that this is a ground truth
-                graph with sparse annotations. This flag will be detected by Metrics and used to
-                set the `sparse_only` flag during metric computatation.
+                graph with sparse annotations, i.e. only a subset of the real objects are
+                annotated. This flag will be detected by Metrics and used to set the
+                `sparse_only` flag during metric computation. Read-only after construction,
+                since it describes the annotations rather than a per-run choice.
+                Defaults to False.
         """
         if segmentation is not None and segmentation.dtype.kind not in ["i", "u"]:
             raise TypeError(f"Segmentation must have integer dtype, found {segmentation.dtype}")
@@ -230,7 +233,7 @@ class TrackingGraph:
         self.location_keys = location_keys
         self.name = name
         self.border_margin = border_margin
-        self.is_sparse_gt = is_sparse_gt
+        self._is_sparse_gt = is_sparse_gt
 
         self.graph = graph
 
@@ -423,6 +426,20 @@ class TrackingGraph:
             "TrackingGraph edges must go strictly forward in time (no "
             "self-loops or cycles)."
         )
+
+    @property
+    def is_sparse_gt(self) -> bool:
+        """Whether this graph is ground truth with sparse annotations.
+
+        Read-only: sparseness describes the annotations, so flipping it after
+        construction would silently change the meaning of any results already
+        computed from this graph. Pass ``is_sparse_gt`` to the constructor or to a
+        loader instead.
+
+        Returns:
+            bool: True if only a subset of the real objects are annotated.
+        """
+        return self._is_sparse_gt
 
     @property
     def nodes(self) -> NodeView:

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -159,6 +159,7 @@ class TrackingGraph:
         name: str | None = None,
         validate: bool = True,
         border_margin: float | None = None,
+        is_sparse_gt: bool = False,
     ):
         """A directed graph representing a tracking solution where edges go
         forward in time.
@@ -198,6 +199,9 @@ class TrackingGraph:
                 will be excluded from the graph, along with their edges. Requires
                 ``segmentation`` and ``location_keys`` (as a tuple) to be provided.
                 Defaults to None (no filtering).
+            is_sparse_gt (bool, optional): If set to True, denotes that this is a ground truth
+                graph with sparse annotations. This flag will be detected by Metrics and used to
+                set the `sparse_only` flag during metric computatation.
         """
         if segmentation is not None and segmentation.dtype.kind not in ["i", "u"]:
             raise TypeError(f"Segmentation must have integer dtype, found {segmentation.dtype}")
@@ -226,6 +230,7 @@ class TrackingGraph:
         self.location_keys = location_keys
         self.name = name
         self.border_margin = border_margin
+        self.is_sparse_gt = is_sparse_gt
 
         self.graph = graph
 

--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -240,6 +240,7 @@ def load_ctc_data(
     name: str | None = None,
     run_checks: bool = True,
     border_margin: float | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Read the CTC segmentations and track file and create a TrackingGraph.
 
@@ -253,6 +254,10 @@ def load_ctc_data(
         border_margin (float, optional): If set, nodes whose centroid is within this
             distance (in pixels) of the spatial border will be excluded from the graph.
             Defaults to None (no filtering).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
 
     Returns:
         traccuracy.TrackingGraph: TrackingGraph object containing segmentations and graph.
@@ -301,5 +306,10 @@ def load_ctc_data(
         loc_keys = ("y", "x")
 
     return TrackingGraph(
-        G, segmentation=masks, name=name, location_keys=loc_keys, border_margin=border_margin
+        G,
+        segmentation=masks,
+        name=name,
+        location_keys=loc_keys,
+        border_margin=border_margin,
+        is_sparse_gt=is_sparse_gt,
     )

--- a/src/traccuracy/loaders/_geff.py
+++ b/src/traccuracy/loaders/_geff.py
@@ -21,6 +21,7 @@ def load_geff_data(
     name: str | None = None,
     load_all_props: bool = False,
     border_margin: float | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load a graph into memory from a geff file
 
@@ -46,6 +47,10 @@ def load_geff_data(
         border_margin (float, optional): If set, nodes whose centroid is within this
             distance (in pixels) of the spatial border will be excluded from the graph.
             Requires segmentation to be loaded. Defaults to None (no filtering).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
     """
     if load_geff_seg and seg_path is not None:
         raise ValueError('Please specify either load_geff_seg=True or seg_path="path/to/seg.zarr"')
@@ -128,4 +133,5 @@ def load_geff_data(
         location_keys=tuple(spatial_props),
         name=name,
         border_margin=border_margin,
+        is_sparse_gt=is_sparse_gt,
     )

--- a/src/traccuracy/loaders/_napari.py
+++ b/src/traccuracy/loaders/_napari.py
@@ -138,6 +138,7 @@ def load_napari_data(
     seg_id_key: str | None = None,
     name: str | None = None,
     progbar_class: type[tqdm] = tqdm,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load a napari Tracks layer into a TrackingGraph.
 
@@ -244,6 +245,10 @@ def load_napari_data(
             implicit-matching loop. Pass e.g. ``napari.utils.progress`` to show
             the bar in napari's activity dock; defaults to plain ``tqdm``
             (terminal).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on
+            sparse ground truth. Defaults to False.
 
     Raises:
         ValueError: data does not have shape (N, 2 + D) with D in {2, 3}.
@@ -374,5 +379,12 @@ def load_napari_data(
             location_keys=location_keys,
             label_key="segmentation_id",
             name=name,
+            is_sparse_gt=is_sparse_gt,
         )
-    return TrackingGraph(G, frame_key=frame_key, location_keys=location_keys, name=name)
+    return TrackingGraph(
+        G,
+        frame_key=frame_key,
+        location_keys=location_keys,
+        name=name,
+        is_sparse_gt=is_sparse_gt,
+    )

--- a/src/traccuracy/loaders/_point.py
+++ b/src/traccuracy/loaders/_point.py
@@ -17,6 +17,7 @@ def load_point_data(
     seg_id_column: str | None = None,
     name: str | None = None,
     sep: str | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load point-based tracking data into a TrackingGraph from a csv-like file
 
@@ -43,6 +44,10 @@ def load_point_data(
             label id. Defaults to None.
         name (str | None, optional): Optional string to name/describe the dataset. Defaults to None.
         sep (str | None, optional): Passed to pd.read_csv to set the sep kwarg. Defaults to None.
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
 
     Raises:
         ValueError: Must provide either a path or a dataframe
@@ -108,6 +113,17 @@ def load_point_data(
 
     if seg_id_column:
         return TrackingGraph(
-            G, frame_key=time_column, location_keys=pos_columns, label_key=seg_id_column, name=name
+            G,
+            frame_key=time_column,
+            location_keys=pos_columns,
+            label_key=seg_id_column,
+            name=name,
+            is_sparse_gt=is_sparse_gt,
         )
-    return TrackingGraph(G, frame_key=time_column, location_keys=pos_columns, name=name)
+    return TrackingGraph(
+        G,
+        frame_key=time_column,
+        location_keys=pos_columns,
+        name=name,
+        is_sparse_gt=is_sparse_gt,
+    )

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -188,6 +188,14 @@ class Metric(ABC):
             relax_skips_pred=relax_skips_pred,
         )
 
+        # Check if the ground truth graph has the sparse flag set
+        if matched.gt_graph.is_sparse_gt and not sparse_only:
+            sparse_only = True
+            warnings.warn(
+                "GT graph is marked is_sparse_gt=True. Setting Metrics sparse_only flag to True",
+                stacklevel=2,
+            )
+
         if sparse_only:
             res_dict = self._filter_sparse_safe(_res_dict)
             if _is_empty_result(res_dict):

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -17,12 +17,43 @@ if TYPE_CHECKING:
 MATCHING_TYPES = ["one-to-one", "one-to-many", "many-to-one", "many-to-many"]
 
 
+def _is_empty_result(results: dict) -> bool:
+    """True if `results` has no leaf values, recursing into nested dicts."""
+    if not results:
+        return True
+    return all(isinstance(v, dict) and _is_empty_result(v) for v in results.values())
+
+
 class Metric(ABC):
     """The base class for Metrics
 
     Data should be passed directly into the compute method
     Kwargs should be specified in the constructor
+
+    Most metrics assume **dense** ground truth (every real cell is annotated), so a
+    predicted node/edge/division with no ground truth match is treated as a false
+    positive. On **sparse** ground truth, where only a subset of cells are
+    annotated, that over-penalizes correct predictions of unannotated cells.
+
+    Subclasses can classify each key in the dict returned by ``_compute`` (matched
+    by name, regardless of how deeply it is nested, e.g. under a per-frame-buffer
+    bucket) via ``sparse_safe_keys`` and ``agnostic_keys``:
+
+    - ``sparse_safe_keys``: the key is a quality/error assessment that only judges
+      structure the annotation can judge (matches, ground-truth-only counts, false
+      negatives), so it remains valid when ground truth is sparse.
+    - ``agnostic_keys``: the key is a raw count or other value that is not itself a
+      quality assessment (e.g. "Total GT Nodes", "Total Pred Nodes"). It is accurate
+      regardless of annotation density, so no claim is made either way.
+    - Anything not listed in either set is treated as dense-only: it counts or
+      derives from unmatched predictions (false positives, precision, F1, ...) and
+      will over-penalize correct predictions of unannotated ground truth.
     """
+
+    #: See the "sparse-safe" bullet in the class docstring.
+    sparse_safe_keys: frozenset[str] = frozenset()
+    #: See the "agnostic" bullet in the class docstring.
+    agnostic_keys: frozenset[str] = frozenset()
 
     def __init__(self, valid_matches: list, zero_division: float = np.nan):
         """Initialize metric.
@@ -53,6 +84,45 @@ class Metric(ABC):
             raise AttributeError("Metric subclass does not define valid_match_types")
         return matched.matching_type in self.valid_match_types
 
+    def _classify_sparse_safe(self, key: str) -> str:
+        """Classify a single output key from ``_compute`` for sparse ground truth.
+
+        Args:
+            key: A key from the dict returned by ``_compute``, e.g. "False Positive
+                Nodes". For nested results (e.g. per-frame-buffer buckets), pass the
+                inner leaf key, not the outer bucket key.
+
+        Returns:
+            str: One of "sparse_safe", "agnostic", or "dense_only". See the class
+                docstring for what each means.
+        """
+        if key in type(self).sparse_safe_keys:
+            return "sparse_safe"
+        if key in type(self).agnostic_keys:
+            return "agnostic"
+        return "dense_only"
+
+    def _filter_sparse_safe(self, results: dict) -> dict:
+        """Recursively filter a ``_compute`` results dict down to sparse-safe/agnostic keys.
+
+        Keys whose value is itself a dict (e.g. the "Frame Buffer 0" buckets in
+        ``DivisionMetrics``) are recursed into rather than classified directly,
+        since only their leaf keys represent actual metric values.
+
+        Args:
+            results: A (possibly nested) dict as returned by ``_compute``.
+
+        Returns:
+            dict: `results` with every dense-only leaf key removed.
+        """
+        filtered = {}
+        for key, value in results.items():
+            if isinstance(value, dict):
+                filtered[key] = self._filter_sparse_safe(value)
+            elif self._classify_sparse_safe(key) in ("sparse_safe", "agnostic"):
+                filtered[key] = value
+        return filtered
+
     @abstractmethod
     def _compute(
         self, matched: Matched, relax_skips_gt: bool = False, relax_skips_pred: bool = False
@@ -80,6 +150,7 @@ class Metric(ABC):
         override_matcher: bool = False,
         relax_skips_gt: bool = False,
         relax_skips_pred: bool = False,
+        sparse_only: bool = False,
     ) -> Results:
         """The compute methods of Metric objects return a Results object populated with results
         and associated metadata
@@ -91,6 +162,7 @@ class Metric(ABC):
                 graph have an equivalent multi-edge path in predicted graph
             relax_skips_pred (bool): If True, the metric will check if skips in the predicted
                 graph have an equivalent multi-edge path in ground truth graph
+            sparse_only (bool): If True, returns only metrics that are valid on sparse ground truth
 
         Returns:
             traccuracy.metrics._results.Results: Object containing metric results
@@ -110,15 +182,28 @@ class Metric(ABC):
                     "of the metric. Check the documentation for the metric for more information."
                 )
 
-        res_dict = self._compute(
+        _res_dict = self._compute(
             matched,
             relax_skips_gt=relax_skips_gt,
             relax_skips_pred=relax_skips_pred,
         )
 
+        if sparse_only:
+            res_dict = self._filter_sparse_safe(_res_dict)
+            if _is_empty_result(res_dict):
+                warnings.warn(
+                    f"{type(self).__name__} has no sparse-safe or agnostic keys, so "
+                    "sparse_only=True filtered every result out. This metric is not "
+                    "meaningful on sparse ground truth.",
+                    stacklevel=2,
+                )
+        else:
+            res_dict = _res_dict
+
         run_info = self.info
         run_info["relax_skips_gt"] = relax_skips_gt
         run_info["relax_skips_pred"] = relax_skips_pred
+        run_info["sparse_only"] = sparse_only
 
         results = Results(
             results=res_dict,
@@ -138,7 +223,14 @@ class Metric(ABC):
     @property
     def info(self) -> dict[str, Any]:
         """Dictionary with Metric name and any parameters"""
-        return {"name": self.__class__.__name__, **self.__dict__}
+        return {
+            "name": self.__class__.__name__,
+            **self.__dict__,
+            # Converted to sorted tuples (rather than mirrored as instance attributes)
+            # so they stay JSON-serializable in ``Results.metric_info``.
+            "sparse_safe_keys": tuple(sorted(type(self).sparse_safe_keys)),
+            "agnostic_keys": tuple(sorted(type(self).agnostic_keys)),
+        }
 
     def _get_precision(self, numerator: int, denominator: int) -> float:
         """Compute precision.

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -95,7 +95,36 @@ class Metric(ABC):
             return "agnostic"
         return "dense_only"
 
-    def _filter_sparse_safe(self, results: dict) -> dict:
+    #: Substrings (matched case-insensitively) identifying sparse-safe keys that are still
+    #: susceptible to inflation from over-prediction on sparse ground truth, e.g. "Node Recall"
+    #: or "complete_lineages". See ``_sparse_caveats``.
+    _sparse_inflatable_substrings = (
+        "recall",
+        "accuracy",
+        "complete_",
+        "track_fractions",
+        "target_effectiveness",
+    )
+
+    def _sparse_caveats(self, key: str) -> str | None:
+        """Warn if a sparse-safe key can still be inflated by over-prediction.
+
+        Args:
+            key: A key from the dict returned by ``_compute``.
+
+        Returns:
+            str | None: A warning message if ``key`` matches one of
+                ``_sparse_inflatable_substrings``, else None.
+        """
+        key_lower = key.lower()
+        if any(substring in key_lower for substring in self._sparse_inflatable_substrings):
+            return (
+                f"Warning: {key} on sparse ground truth can be inflated by predicting way too "
+                "many nodes/edges. Don't use this metric in isolation to compare methods."
+            )
+        return None
+
+    def _filter_sparse_safe(self, results: dict) -> tuple[dict, list[str]]:
         """Recursively filter a ``_compute`` results dict down to sparse-safe/agnostic keys.
 
         Keys whose value is itself a dict (e.g. the "Frame Buffer 0" buckets in
@@ -107,14 +136,23 @@ class Metric(ABC):
 
         Returns:
             dict: `results` with every dense-only leaf key removed.
+            list[str]: Deduplicated warnings about sparse-safe keys that can still be
+                inflated by over-prediction (see ``_sparse_caveats``). Nested buckets
+                (e.g. per-frame-buffer) commonly repeat the same leaf key, so the same
+                caveat is only reported once.
         """
         filtered = {}
+        caveats: dict[str, None] = {}  # dict used as an ordered set to dedupe caveats
         for key, value in results.items():
             if isinstance(value, dict):
-                filtered[key] = self._filter_sparse_safe(value)
+                filtered[key], nested_caveats = self._filter_sparse_safe(value)
+                caveats.update(dict.fromkeys(nested_caveats))
             elif self._classify_sparse_safe(key) in ("sparse_safe", "agnostic"):
                 filtered[key] = value
-        return filtered
+                caveat = self._sparse_caveats(key)
+                if caveat is not None:
+                    caveats[caveat] = None
+        return filtered, list(caveats)
 
     @abstractmethod
     def _compute(
@@ -190,6 +228,7 @@ class Metric(ABC):
 
         # Whether anything can survive filtering is a class-level property, so answer it
         # before paying for _compute instead of computing and discarding everything.
+        caveats: list = []
         res_dict: dict
         if sparse_only and not (type(self).sparse_safe_keys | type(self).agnostic_keys):
             warnings.warn(
@@ -206,12 +245,15 @@ class Metric(ABC):
                 relax_skips_pred=relax_skips_pred,
             )
             if sparse_only:
-                res_dict = self._filter_sparse_safe(res_dict)
+                res_dict, caveats = self._filter_sparse_safe(res_dict)
 
         run_info = self.info
         run_info["relax_skips_gt"] = relax_skips_gt
         run_info["relax_skips_pred"] = relax_skips_pred
         run_info["sparse_only"] = sparse_only
+
+        if caveats:
+            run_info["sparse_metric_warnings"] = caveats
 
         results = Results(
             results=res_dict,

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -32,9 +32,9 @@ class Metric(ABC):
     by name, regardless of how deeply it is nested, e.g. under a per-frame-buffer
     bucket) via ``sparse_safe_keys`` and ``agnostic_keys``:
 
-    - ``sparse_safe_keys``: the key is a quality/error assessment that only judges
-      structure the annotation can judge (matches, ground-truth-only counts, false
-      negatives), so it remains valid when ground truth is sparse.
+    - ``sparse_safe_keys``: the key is a quality/error assessment that does not
+      assume predictions with no match are false positives so it remains valid when
+      ground truth is sparse.
     - ``agnostic_keys``: the key is a raw count or other value that is not itself a
       quality assessment (e.g. "Total GT Nodes", "Total Pred Nodes"). It is accurate
       regardless of annotation density, so no claim is made either way.

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -17,13 +17,6 @@ if TYPE_CHECKING:
 MATCHING_TYPES = ["one-to-one", "one-to-many", "many-to-one", "many-to-many"]
 
 
-def _is_empty_result(results: dict) -> bool:
-    """True if `results` has no leaf values, recursing into nested dicts."""
-    if not results:
-        return True
-    return all(isinstance(v, dict) and _is_empty_result(v) for v in results.values())
-
-
 class Metric(ABC):
     """The base class for Metrics
 
@@ -162,7 +155,11 @@ class Metric(ABC):
                 graph have an equivalent multi-edge path in predicted graph
             relax_skips_pred (bool): If True, the metric will check if skips in the predicted
                 graph have an equivalent multi-edge path in ground truth graph
-            sparse_only (bool): If True, returns only metrics that are valid on sparse ground truth
+            sparse_only (bool): If True, returns only metrics that are valid on sparse ground
+                truth. A ``matched.gt_graph`` constructed with ``is_sparse_gt=True`` forces this
+                on regardless, since sparseness is a property of the annotations. If the metric
+                declares no sparse-safe or agnostic keys at all it cannot report anything, so
+                ``_compute`` is skipped and an empty result is returned with a warning.
 
         Returns:
             traccuracy.metrics._results.Results: Object containing metric results
@@ -182,13 +179,8 @@ class Metric(ABC):
                     "of the metric. Check the documentation for the metric for more information."
                 )
 
-        _res_dict = self._compute(
-            matched,
-            relax_skips_gt=relax_skips_gt,
-            relax_skips_pred=relax_skips_pred,
-        )
-
-        # Check if the ground truth graph has the sparse flag set
+        # Sparseness is a property of the annotations, not a per-run choice, so a GT graph
+        # marked sparse forces filtering on.
         if matched.gt_graph.is_sparse_gt and not sparse_only:
             sparse_only = True
             warnings.warn(
@@ -196,17 +188,25 @@ class Metric(ABC):
                 stacklevel=2,
             )
 
-        if sparse_only:
-            res_dict = self._filter_sparse_safe(_res_dict)
-            if _is_empty_result(res_dict):
-                warnings.warn(
-                    f"{type(self).__name__} has no sparse-safe or agnostic keys, so "
-                    "sparse_only=True filtered every result out. This metric is not "
-                    "meaningful on sparse ground truth.",
-                    stacklevel=2,
-                )
+        # Whether anything can survive filtering is a class-level property, so answer it
+        # before paying for _compute instead of computing and discarding everything.
+        res_dict: dict
+        if sparse_only and not (type(self).sparse_safe_keys | type(self).agnostic_keys):
+            warnings.warn(
+                f"{type(self).__name__} has no sparse-safe or agnostic keys, so "
+                "sparse_only=True filtered every result out. This metric is not "
+                "meaningful on sparse ground truth.",
+                stacklevel=2,
+            )
+            res_dict = {}
         else:
-            res_dict = _res_dict
+            res_dict = self._compute(
+                matched,
+                relax_skips_gt=relax_skips_gt,
+                relax_skips_pred=relax_skips_pred,
+            )
+            if sparse_only:
+                res_dict = self._filter_sparse_safe(res_dict)
 
         run_info = self.info
         run_info["relax_skips_gt"] = relax_skips_gt

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -41,12 +41,48 @@ class Metric(ABC):
     - Anything not listed in either set is treated as dense-only: it counts or
       derives from unmatched predictions (false positives, precision, F1, ...) and
       will over-penalize correct predictions of unannotated ground truth.
+
+    The two sets must be disjoint frozensets; ``__init_subclass__`` checks that when
+    the subclass is defined.
     """
 
     #: See the "sparse-safe" bullet in the class docstring.
     sparse_safe_keys: frozenset[str] = frozenset()
     #: See the "agnostic" bullet in the class docstring.
     agnostic_keys: frozenset[str] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Check a subclass's declared key sets when the class is defined.
+
+        Runs at class definition rather than on instantiation, so a contradictory
+        declaration fails on import instead of lurking in a metric that a given run
+        never happens to instantiate.
+
+        Args:
+            **kwargs: Forwarded to ``super().__init_subclass__``.
+
+        Raises:
+            TypeError: Either declaration is not a frozenset.
+            ValueError: A key is declared both sparse-safe and agnostic.
+        """
+        super().__init_subclass__(**kwargs)
+        for name in ("sparse_safe_keys", "agnostic_keys"):
+            declared = getattr(cls, name)
+            if not isinstance(declared, frozenset):
+                raise TypeError(
+                    f"{cls.__name__}.{name} must be a frozenset, got "
+                    f"{type(declared).__name__}. Declared key sets are immutable so "
+                    "they cannot be edited into an overlap in place after this check "
+                    "runs; rebinding the attribute later is still unchecked."
+                )
+        overlap = cls.sparse_safe_keys & cls.agnostic_keys
+        if overlap:
+            raise ValueError(
+                f"{cls.__name__} declares {sorted(overlap)} as both sparse-safe and "
+                "agnostic (either side may be inherited). _classify_sparse_safe "
+                "resolves such a key to sparse-safe and the contradiction goes "
+                "unnoticed, so put each key in exactly one set."
+            )
 
     def __init__(self, valid_matches: list, zero_division: float = np.nan):
         """Initialize metric.

--- a/src/traccuracy/metrics/_basic.py
+++ b/src/traccuracy/metrics/_basic.py
@@ -26,6 +26,27 @@ class BasicMetrics(Metric):
     Consider eliminating metrics that use the number of false positives.
     """
 
+    # True positives, false negatives, and recall only judge structure the ground
+    # truth annotates, so they remain valid on sparse ground truth. Totals are raw
+    # counts, not a judgment either way. Everything else (false positives, precision,
+    # F1) treats an unmatched prediction as an error and is dense-only.
+    sparse_safe_keys = frozenset(
+        {
+            "True Positive Nodes",
+            "True Positive Edges",
+            "False Negative Nodes",
+            "False Negative Edges",
+            "Node Recall",
+            "Edge Recall",
+            "Skip GT True Positive Edges",
+            "Skip Pred True Positive Edges",
+            "Skip False Negative Edges",
+        }
+    )
+    agnostic_keys = frozenset(
+        {"Total GT Nodes", "Total GT Edges", "Total Pred Nodes", "Total Pred Edges"}
+    )
+
     def __init__(self) -> None:
         super().__init__(VALID_MATCHING_TYPES)
 

--- a/src/traccuracy/metrics/_complete_tracks.py
+++ b/src/traccuracy/metrics/_complete_tracks.py
@@ -52,6 +52,15 @@ class CompleteTracks(Metric):
 
     """
 
+    # Only ground-truth tracklets/lineages are scored; predictions beyond the ground
+    # truth are never penalized, so the correctness/completeness fractions are valid on
+    # sparse ground truth. The `total_*` counts are just ground-truth sizes, not a
+    # judgment either way.
+    sparse_safe_keys = frozenset(
+        {"correct_lineages", "correct_tracklets", "complete_lineages", "complete_tracklets"}
+    )
+    agnostic_keys = frozenset({"total_lineages", "total_tracklets"})
+
     def __init__(self, error_type: str = "basic"):
         valid_matches = ["one-to-one", "many-to-one"]
         super().__init__(valid_matches)

--- a/src/traccuracy/metrics/_complete_tracks_by_length.py
+++ b/src/traccuracy/metrics/_complete_tracks_by_length.py
@@ -74,6 +74,12 @@ class CompleteTracksByLength(Metric):
 
     """
 
+    # Only ground-truth segments are scored; predictions beyond the ground truth are
+    # never penalized, so `correct`/`accuracy` are valid on sparse ground truth.
+    # `total` is just the ground-truth segment count, not a judgment either way.
+    sparse_safe_keys = frozenset({"correct", "accuracy"})
+    agnostic_keys = frozenset({"total"})
+
     def __init__(
         self,
         max_length: int | None = None,

--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -35,6 +35,12 @@ class AOGMMetrics(Metric):
         edge_ws_weight (float): Weight for wrong semantic edge errors. Defaults to 1
     """
 
+    # The false negative counts are read off the ground truth graph, so they only judge
+    # objects the annotation covers and hold on sparse ground truth. AOGM itself (and the
+    # TRA/DET/LNK scores derived from it in CTCMetrics) sums in the false-positive,
+    # non-split and wrong-semantic terms, so those stay dense-only.
+    sparse_safe_keys = frozenset({"fn_nodes", "fn_edges"})
+
     def __init__(
         self,
         vertex_ns_weight: float = 1,

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -78,6 +78,21 @@ class DivisionMetrics(Metric):
             similar to scikit-learn's ``zero_division`` parameter.
     """
 
+    # Recall, true/false-negative counts, and wrong-children counts only judge
+    # divisions the ground truth annotates, so they remain valid on sparse ground
+    # truth. Totals are raw counts, not a judgment either way. Precision, F1, and MBC
+    # all use the false-positive-division count and are dense-only.
+    sparse_safe_keys = frozenset(
+        {
+            "Division Recall",
+            "True Positive Divisions",
+            "False Negative Divisions",
+            "Wrong Children Divisions",
+            "True Positive Skip Divisions",
+        }
+    )
+    agnostic_keys = frozenset({"Total GT Divisions", "Total Predicted Divisions"})
+
     def __init__(self, max_frame_buffer: int = 0, zero_division: float = np.nan) -> None:
         super().__init__(VALID_MATCHING_TYPES, zero_division=zero_division)
 

--- a/src/traccuracy/metrics/_track_overlap.py
+++ b/src/traccuracy/metrics/_track_overlap.py
@@ -46,6 +46,13 @@ class TrackOverlapMetrics(Metric):
 
     """
 
+    # Target effectiveness/track fractions score how much of each ground-truth
+    # tracklet is covered by its best-overlapping prediction, ignoring prediction
+    # beyond the ground truth, so they remain valid on sparse ground truth. Track
+    # purity is the inverse (how much of each *predicted* tracklet is covered by
+    # ground truth), so an unannotated-but-correct prediction tanks it: dense-only.
+    sparse_safe_keys = frozenset({"target_effectiveness", "track_fractions"})
+
     def __init__(self, include_division_edges: bool = True):
         valid_match_types = ["many-to-one", "one-to-one", "one-to-many"]
         super().__init__(valid_match_types)

--- a/tests/loaders/test_ctc.py
+++ b/tests/loaders/test_ctc.py
@@ -116,6 +116,16 @@ def test_load_data():
     assert len(track_data.segmentation) == 92
 
 
+def test_load_data_is_sparse_gt():
+    test_dir = os.path.abspath(__file__)
+    data_dir = os.path.abspath(
+        os.path.join(test_dir, "../../../examples/sample-data/Fluo-N2DL-HeLa/01_RES/")
+    )
+    track_path = os.path.join(data_dir, "res_track.txt")
+    assert _ctc.load_ctc_data(data_dir, track_path).is_sparse_gt is False
+    assert _ctc.load_ctc_data(data_dir, track_path, is_sparse_gt=True).is_sparse_gt is True
+
+
 def test_load_data_no_track_path():
     test_dir = os.path.abspath(__file__)
     data_dir = os.path.abspath(

--- a/tests/loaders/test_geff.py
+++ b/tests/loaders/test_geff.py
@@ -38,6 +38,18 @@ class Test_load_geff_data:
         tg = load_geff_data(zarr_path, load_all_props=True)
         assert "score" in tg.graph.edges[(0, 1)]
 
+    def test_is_sparse_gt(self, tmp_path):
+        zarr_path = tmp_path / "test.zarr"
+        store, _ = create_simple_2d_geff(directed=True)
+        graph, meta = read(store, backend="networkx")
+        time_key = next(ax.name for ax in meta.axes if ax.type == "time")
+        for node in graph.nodes:
+            graph.nodes[node][time_key] = float(node)
+        write(graph, zarr_path, meta)
+
+        assert load_geff_data(zarr_path).is_sparse_gt is False
+        assert load_geff_data(zarr_path, is_sparse_gt=True).is_sparse_gt is True
+
     def test_undirected(self, tmp_path):
         zarr_path = tmp_path / "test.zarr"
         store, _ = create_simple_2d_geff(directed=False)

--- a/tests/loaders/test_napari.py
+++ b/tests/loaders/test_napari.py
@@ -19,6 +19,17 @@ class Test_load_napari_data:
         assert first["t"] == 0 and isinstance(first["t"], int)
         assert first["y"] == 10 and first["x"] == 20
 
+    def test_is_sparse_gt(self):
+        data = np.array([[1, 0, 10, 20], [1, 1, 11, 21]], dtype=float)
+        assert load_napari_data(data).is_sparse_gt is False
+        assert load_napari_data(data, is_sparse_gt=True).is_sparse_gt is True
+        # The segmentation branch constructs a separate TrackingGraph.
+        seg = np.zeros((2, 30, 30), dtype=np.uint16)
+        seg[0, 9:12, 19:22] = 1
+        seg[1, 10:13, 20:23] = 1
+        tg = load_napari_data(data, segmentation=seg, is_sparse_gt=True)
+        assert tg.is_sparse_gt is True
+
     def test_3d_locations(self):
         data = np.array([[1, 0, 3, 4, 5], [1, 1, 3, 4, 5]], dtype=float)
         tg = load_napari_data(data)

--- a/tests/loaders/test_point.py
+++ b/tests/loaders/test_point.py
@@ -77,6 +77,15 @@ class Test_load_point_data:
         ):
             load_point_data(df=df, name="test")
 
+    def test_is_sparse_gt(self):
+        df = self.get_valid_df(5)
+        assert load_point_data(df=df).is_sparse_gt is False
+        assert load_point_data(df=df, is_sparse_gt=True).is_sparse_gt is True
+        # The seg_id_column branch constructs a separate TrackingGraph.
+        df_seg = df.assign(seg_label=range(5))
+        graph = load_point_data(df=df_seg, seg_id_column="seg_label", is_sparse_gt=True)
+        assert graph.is_sparse_gt is True
+
     def test_load_from_dataframe(self):
         # Make a valid dataframe using defaults
         nrows = 5

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -1,3 +1,5 @@
+import warnings
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -187,12 +189,17 @@ class TestMetric:
         assert results.metric_info["sparse_safe_keys"] == ("safe_key",)
         assert results.metric_info["agnostic_keys"] == ("neutral_key",)
 
-    def test_sparse_only_warns_when_metric_has_no_safe_keys(self):
-        # A metric that declares no sparse-safe/agnostic keys (the default) has
-        # nothing left after filtering; sparse_only=True should say so rather than
-        # silently handing back an empty dict.
+    def test_sparse_only_skips_metric_with_no_safe_keys(self):
+        # A metric that declares no sparse-safe/agnostic keys (the default) can never
+        # report anything under sparse_only, which is knowable from the class alone --
+        # so _compute should be skipped entirely rather than computed and discarded.
         class DenseOnlyMetric(ValidMetric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.computed = False
+
             def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                self.computed = True
                 return {"dense_key": 1}
 
         matched = Matched(
@@ -201,8 +208,31 @@ class TestMetric:
             [],
             {"matching type": "one-to-one"},
         )
+        metric = DenseOnlyMetric()
         with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
-            results = DenseOnlyMetric().compute(matched, sparse_only=True)
+            results = metric.compute(matched, sparse_only=True)
+        assert results.results == {}
+        assert metric.computed is False
+
+    def test_sparse_only_does_not_warn_when_compute_is_legitimately_empty(self):
+        # An empty _compute result must not be mistaken for "this metric has no
+        # sparse-safe keys" -- e.g. CompleteTracksByLength returns {} for a graph with
+        # no frame range while declaring three sparse-safe/agnostic keys.
+        class EmptyResultMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+
+            def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                return {}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph()),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            results = EmptyResultMetric().compute(matched, sparse_only=True)
         assert results.results == {}
 
     def test_set_sparse_to_true_with_sparse_gt(self):
@@ -212,7 +242,7 @@ class TestMetric:
             agnostic_keys = frozenset({"neutral_key"})
 
             def _compute(self, matched, relax_skips_gt, relax_skips_pred):
-                return {"safe_key": 0, "neutral_key": 1}
+                return {"safe_key": 0, "neutral_key": 1, "dense_key": 2}
 
         matched = Matched(
             TrackingGraph(nx.DiGraph(), is_sparse_gt=True),
@@ -227,6 +257,27 @@ class TestMetric:
         ):
             results = MixedMetric().compute(matched)
         assert results.metric_info["sparse_only"] is True
+        # The flag actually filtered, rather than only being recorded in the metadata.
+        assert results.results == {"safe_key": 0, "neutral_key": 1}
+
+    def test_explicit_sparse_only_false_does_not_override_sparse_gt(self):
+        # Sparseness describes the annotations, so the graph flag wins over the kwarg.
+        class MixedMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+
+            def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                return {"safe_key": 0, "dense_key": 1}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph(), is_sparse_gt=True),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        with pytest.warns(UserWarning, match="GT graph is marked is_sparse_gt=True"):
+            results = MixedMetric().compute(matched, sparse_only=False)
+        assert results.metric_info["sparse_only"] is True
+        assert results.results == {"safe_key": 0}
 
 
 def test_filter_sparse_safe_flat_dict():

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -173,6 +173,34 @@ class TestMetric:
         assert m._classify_sparse_safe("neutral_key") == "agnostic"
         assert m._classify_sparse_safe("other_key") == "dense_only"
 
+    def test_overlapping_key_sets_raise_at_class_definition(self):
+        # Caught when the class is defined, so a bad declaration cannot hide in a
+        # metric that a given run never instantiates.
+        with pytest.raises(ValueError, match="both sparse-safe and agnostic"):
+
+            class ContradictoryMetric(ValidMetric):
+                sparse_safe_keys = frozenset({"shared_key", "safe_key"})
+                agnostic_keys = frozenset({"shared_key"})
+
+    def test_mutable_key_set_is_rejected(self):
+        # A mutable set could be edited into an overlap after __init_subclass__ has
+        # already passed, which a frozenset makes impossible.
+        with pytest.raises(TypeError, match="must be a frozenset"):
+
+            class MutableMetric(ValidMetric):
+                sparse_safe_keys = {"safe_key"}  # noqa: RUF012
+
+    def test_overlap_is_detected_through_inheritance(self):
+        # CTCMetrics inherits its keys from AOGMMetrics, so the check has to look at
+        # the resolved values rather than only what this class body declares.
+        class Parent(ValidMetric):
+            sparse_safe_keys = frozenset({"shared_key"})
+
+        with pytest.raises(ValueError, match="both sparse-safe and agnostic"):
+
+            class Child(Parent):
+                agnostic_keys = frozenset({"shared_key"})
+
     def test_classify_sparse_gt_surfaces_in_results(self):
         class MixedMetric(ValidMetric):
             sparse_safe_keys = frozenset({"safe_key"})

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -149,3 +149,91 @@ class TestMetric:
         results = m.compute(self.matched, relax_skips_gt=True, relax_skips_pred=False)
         assert results.metric_info["relax_skips_gt"] is True
         assert results.metric_info["relax_skips_pred"] is False
+
+    def test_classify_sparse_gt_default_dense_only(self):
+        # A metric that does not opt in classifies every key as dense-only.
+        m = ValidMetric()
+        assert m._classify_sparse_safe("anything") == "dense_only"
+        assert m.sparse_safe_keys == frozenset()
+        assert m.agnostic_keys == frozenset()
+        assert m.info["sparse_safe_keys"] == ()
+        assert m.info["agnostic_keys"] == ()
+
+    def test_classify_sparse_gt_opt_in(self):
+        # A subclass can declare specific keys as sparse-safe or agnostic; anything
+        # else still falls back to dense-only.
+        class MixedMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+            agnostic_keys = frozenset({"neutral_key"})
+
+        m = MixedMetric()
+        assert m._classify_sparse_safe("safe_key") == "sparse_safe"
+        assert m._classify_sparse_safe("neutral_key") == "agnostic"
+        assert m._classify_sparse_safe("other_key") == "dense_only"
+
+    def test_classify_sparse_gt_surfaces_in_results(self):
+        class MixedMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+            agnostic_keys = frozenset({"neutral_key"})
+
+        # Fresh matched with the matching type set so no "empty mapping" warning fires.
+        matched = Matched(
+            TrackingGraph(nx.DiGraph()),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        results = MixedMetric().compute(matched)
+        assert results.metric_info["sparse_safe_keys"] == ("safe_key",)
+        assert results.metric_info["agnostic_keys"] == ("neutral_key",)
+
+    def test_sparse_only_warns_when_metric_has_no_safe_keys(self):
+        # A metric that declares no sparse-safe/agnostic keys (the default) has
+        # nothing left after filtering; sparse_only=True should say so rather than
+        # silently handing back an empty dict.
+        class DenseOnlyMetric(ValidMetric):
+            def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                return {"dense_key": 1}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph()),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
+            results = DenseOnlyMetric().compute(matched, sparse_only=True)
+        assert results.results == {}
+
+
+def test_filter_sparse_safe_flat_dict():
+    # A metric's own classification is tested per-metric (see e.g. test_basic.py,
+    # test_divisions.py); this only tests the generic filtering mechanism.
+    class MixedMetric(ValidMetric):
+        sparse_safe_keys = frozenset({"safe_key"})
+        agnostic_keys = frozenset({"neutral_key"})
+
+    m = MixedMetric()
+    filtered = m._filter_sparse_safe({"safe_key": 1, "neutral_key": 2, "dense_only_key": 3})
+    assert filtered == {"safe_key": 1, "neutral_key": 2}
+
+
+def test_filter_sparse_safe_recurses_into_nested_dicts():
+    # A key whose value is itself a dict (e.g. a per-frame-buffer bucket) is
+    # recursed into rather than classified directly -- only its leaf keys
+    # represent actual metric values.
+    class MixedMetric(ValidMetric):
+        sparse_safe_keys = frozenset({"safe_key"})
+        agnostic_keys = frozenset({"neutral_key"})
+
+    m = MixedMetric()
+    filtered = m._filter_sparse_safe(
+        {
+            "Bucket 0": {"safe_key": 1, "neutral_key": 2, "dense_only_key": 3},
+            "Bucket 1": {"safe_key": 4, "dense_only_key": 5},
+        }
+    )
+    assert filtered == {
+        "Bucket 0": {"safe_key": 1, "neutral_key": 2},
+        "Bucket 1": {"safe_key": 4},
+    }

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -288,7 +288,7 @@ def test_filter_sparse_safe_flat_dict():
         agnostic_keys = frozenset({"neutral_key"})
 
     m = MixedMetric()
-    filtered = m._filter_sparse_safe({"safe_key": 1, "neutral_key": 2, "dense_only_key": 3})
+    filtered, _ = m._filter_sparse_safe({"safe_key": 1, "neutral_key": 2, "dense_only_key": 3})
     assert filtered == {"safe_key": 1, "neutral_key": 2}
 
 
@@ -301,7 +301,7 @@ def test_filter_sparse_safe_recurses_into_nested_dicts():
         agnostic_keys = frozenset({"neutral_key"})
 
     m = MixedMetric()
-    filtered = m._filter_sparse_safe(
+    filtered, _ = m._filter_sparse_safe(
         {
             "Bucket 0": {"safe_key": 1, "neutral_key": 2, "dense_only_key": 3},
             "Bucket 1": {"safe_key": 4, "dense_only_key": 5},
@@ -311,3 +311,33 @@ def test_filter_sparse_safe_recurses_into_nested_dicts():
         "Bucket 0": {"safe_key": 1, "neutral_key": 2},
         "Bucket 1": {"safe_key": 4},
     }
+
+
+def test_filter_sparse_safe_caveats():
+    # Sparse-safe keys that can still be inflated by over-prediction (e.g. "recall") should
+    # produce a caveat; other sparse-safe/agnostic keys should not.
+    class MixedMetric(ValidMetric):
+        sparse_safe_keys = frozenset({"Node Recall", "True Positive Nodes"})
+        agnostic_keys = frozenset({"neutral_key"})
+
+    m = MixedMetric()
+    _, caveats = m._filter_sparse_safe(
+        {"Node Recall": 0.5, "True Positive Nodes": 1, "neutral_key": 2, "dense_only_key": 3}
+    )
+    assert caveats == [m._sparse_caveats("Node Recall")]
+
+
+def test_filter_sparse_safe_caveats_deduplicated_across_nested_dicts():
+    # Nested buckets (e.g. per-frame-buffer) commonly repeat the same leaf key, so the same
+    # caveat should only be reported once.
+    class MixedMetric(ValidMetric):
+        sparse_safe_keys = frozenset({"Node Recall"})
+
+    m = MixedMetric()
+    _, caveats = m._filter_sparse_safe(
+        {
+            "Bucket 0": {"Node Recall": 0.5},
+            "Bucket 1": {"Node Recall": 0.6},
+        }
+    )
+    assert caveats == [m._sparse_caveats("Node Recall")]

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -205,6 +205,29 @@ class TestMetric:
             results = DenseOnlyMetric().compute(matched, sparse_only=True)
         assert results.results == {}
 
+    def test_set_sparse_to_true_with_sparse_gt(self):
+        # Warn and override sparse_only flag if gt graph marked as sparse
+        class MixedMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+            agnostic_keys = frozenset({"neutral_key"})
+
+            def _compute(self, matched, relax_skips_gt, relax_skips_pred):
+                return {"safe_key": 0, "neutral_key": 1}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph(), is_sparse_gt=True),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+
+        with pytest.warns(
+            UserWarning,
+            match="GT graph is marked is_sparse_gt=True. Setting Metrics sparse_only flag to True",
+        ):
+            results = MixedMetric().compute(matched)
+        assert results.metric_info["sparse_only"] is True
+
 
 def test_filter_sparse_safe_flat_dict():
     # A metric's own classification is tested per-metric (see e.g. test_basic.py,

--- a/tests/metrics/test_basic.py
+++ b/tests/metrics/test_basic.py
@@ -100,3 +100,39 @@ class TestBasicMetrics:
         assert resdict["Skip Pred True Positive Edges"] == edge_tp_pred_skip
         assert resdict["Skip False Positive Edges"] == edge_fp_skip
         assert resdict["Skip False Negative Edges"] == edge_fn_skip
+
+    def test_sparse_only(self):
+        matched = ex_graphs.all_basic_errors()
+        results = self.m.compute(
+            matched, relax_skips_gt=True, relax_skips_pred=True, sparse_only=True
+        ).results
+
+        # Sparse-safe and agnostic keys survive the filter
+        for key in (
+            "True Positive Nodes",
+            "True Positive Edges",
+            "False Negative Nodes",
+            "False Negative Edges",
+            "Node Recall",
+            "Edge Recall",
+            "Skip GT True Positive Edges",
+            "Skip Pred True Positive Edges",
+            "Skip False Negative Edges",
+            "Total GT Nodes",
+            "Total GT Edges",
+            "Total Pred Nodes",
+            "Total Pred Edges",
+        ):
+            assert key in results
+
+        # Dense-only keys (false positives, precision, F1) are filtered out
+        for key in (
+            "False Positive Nodes",
+            "False Positive Edges",
+            "Node Precision",
+            "Edge Precision",
+            "Node F1",
+            "Edge F1",
+            "Skip False Positive Edges",
+        ):
+            assert key not in results

--- a/tests/metrics/test_complete_tracks.py
+++ b/tests/metrics/test_complete_tracks.py
@@ -238,6 +238,31 @@ def test_larger_example(error_type):
     "ignore:Node errors already calculated",
     "ignore:Edge errors already calculated",
 )
+@pytest.mark.parametrize("error_type", ["basic", "ctc"])
+def test_larger_example_sparse_only_keeps_every_key(error_type):
+    # CompleteTracks never penalizes prediction beyond the ground truth, so
+    # none of its keys are dense-only: sparse_only should be a no-op here.
+    complete_tracks = CompleteTracks(error_type=error_type)
+
+    full = complete_tracks.compute(larger_example_1()).results
+    sparse = complete_tracks.compute(larger_example_1(), sparse_only=True).results
+
+    assert sparse == full
+    assert set(sparse.keys()) == {
+        "total_lineages",
+        "total_tracklets",
+        "correct_lineages",
+        "correct_tracklets",
+        "complete_lineages",
+        "complete_tracklets",
+    }
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Mapping is empty",
+    "ignore:Node errors already calculated",
+    "ignore:Edge errors already calculated",
+)
 def test_invalid_input():
     with pytest.raises(ValueError, match="Unrecognized error type"):
         CompleteTracks(error_type="abcdefg")

--- a/tests/metrics/test_complete_tracks_by_length.py
+++ b/tests/metrics/test_complete_tracks_by_length.py
@@ -69,6 +69,17 @@ class TestLargerExample:
             expected_acc = correct / total
             assert pytest.approx(result.results["accuracy"][idx], abs=0.01) == expected_acc
 
+    def test_larger_example_1_sparse_only_keeps_every_key(self, error_type):
+        # CompleteTracksByLength never penalizes prediction beyond the ground
+        # truth, so none of its keys are dense-only: sparse_only should be a no-op.
+        metric = CompleteTracksByLength(max_length=2, error_type=error_type)
+
+        full = metric.compute(larger_example_1()).results
+        sparse = metric.compute(larger_example_1(), sparse_only=True).results
+
+        assert sparse == full
+        assert set(sparse.keys()) == {"correct", "total", "accuracy"}
+
 
 @pytest.mark.filterwarnings(
     "ignore:Mapping is empty",

--- a/tests/metrics/test_ctc_metrics.py
+++ b/tests/metrics/test_ctc_metrics.py
@@ -72,18 +72,18 @@ def test_compute_mapping():
     assert results["DET"] == 1
 
 
-def test_sparse_only_filters_everything():
-    # CTC/AOGM errors collapse false positives and false negatives into single
-    # inseparable scores, so no key is sparse-safe or agnostic: sparse_only
-    # filters the whole results dict down to nothing.
+def test_sparse_only_keeps_only_false_negative_counts():
+    # The fn counts are read off the gt graph so they survive sparse filtering, but
+    # AOGM and the TRA/DET/LNK scores derived from it fold in the fp/ns/ws terms and
+    # are dropped.
     n_frames = 3
     n_labels = 3
     track_graph = get_movie_with_graph(ndims=3, n_frames=n_frames, n_labels=n_labels)
 
     matched = CTCMatcher().compute_mapping(gt_graph=track_graph, pred_graph=track_graph)
-    with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
-        results = CTCMetrics().compute(matched, sparse_only=True).results
-    assert results == {}
+    results = CTCMetrics().compute(matched, sparse_only=True).results
+
+    assert set(results.keys()) == {"fn_nodes", "fn_edges"}
 
 
 def test_get_det():

--- a/tests/metrics/test_ctc_metrics.py
+++ b/tests/metrics/test_ctc_metrics.py
@@ -72,6 +72,20 @@ def test_compute_mapping():
     assert results["DET"] == 1
 
 
+def test_sparse_only_filters_everything():
+    # CTC/AOGM errors collapse false positives and false negatives into single
+    # inseparable scores, so no key is sparse-safe or agnostic: sparse_only
+    # filters the whole results dict down to nothing.
+    n_frames = 3
+    n_labels = 3
+    track_graph = get_movie_with_graph(ndims=3, n_frames=n_frames, n_labels=n_labels)
+
+    matched = CTCMatcher().compute_mapping(gt_graph=track_graph, pred_graph=track_graph)
+    with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
+        results = CTCMetrics().compute(matched, sparse_only=True).results
+    assert results == {}
+
+
 def test_get_det():
     metrics = CTCMetrics()
     n_nodes = 100

--- a/tests/metrics/test_divisions.py
+++ b/tests/metrics/test_divisions.py
@@ -73,6 +73,33 @@ def test_DivisionMetrics():
             assert r["False Negative Divisions"] == 0
 
 
+def test_sparse_only_filters_nested_frame_buffer_dict():
+    # DivisionMetrics nests its per-key results one level deep under a
+    # "Frame Buffer N" bucket; sparse_only must recurse into each bucket rather
+    # than classifying (and dropping) the bucket key itself.
+    g_gt, g_pred, map_gt, map_pred = get_division_graphs()
+    mapper = list(zip(map_gt, map_pred, strict=False))
+    matched = Matched(TrackingGraph(g_gt), TrackingGraph(g_pred), mapper, {"name": "DummyMatcher"})
+    frame_buffer = 2
+
+    results = (
+        DivisionMetrics(max_frame_buffer=frame_buffer).compute(matched, sparse_only=True).results
+    )
+
+    assert set(results.keys()) == {f"Frame Buffer {i}" for i in range(frame_buffer + 1)}
+    for bucket in results.values():
+        assert "Division Recall" in bucket
+        assert "True Positive Divisions" in bucket
+        assert "False Negative Divisions" in bucket
+        assert "Total GT Divisions" in bucket  # agnostic, kept
+        assert "Total Predicted Divisions" in bucket  # agnostic, kept
+
+        assert "Division Precision" not in bucket
+        assert "Division F1" not in bucket
+        assert "Mitotic Branching Correctness" not in bucket
+        assert "False Positive Divisions" not in bucket
+
+
 def test_division_metrics_perfect():
     _, g_pred, _, _ = get_division_graphs()
     mapper = list(zip(list(g_pred.nodes), list(g_pred.nodes), strict=False))

--- a/tests/metrics/test_sparse_safe_keys.py
+++ b/tests/metrics/test_sparse_safe_keys.py
@@ -1,0 +1,193 @@
+"""Pin each metric's declared sparse-safe/agnostic keys to the keys it actually returns.
+
+``sparse_safe_keys``/``agnostic_keys`` repeat result-key strings that ``_compute`` builds
+independently -- ``BasicMetrics`` composes them with f-strings and never writes them as
+literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, and
+the failure is silent: an unrecognized key is classified ``dense_only`` and quietly dropped
+from sparse results, while a declared key that no longer exists is a dead no-op. These tests
+turn both into a test failure.
+"""
+
+import networkx as nx
+import pytest
+
+import tests.examples.graphs as ex_graphs
+from tests.examples.larger_examples import larger_example_1
+from tests.test_utils import get_division_graphs, get_movie_with_graph
+from traccuracy import TrackingGraph
+from traccuracy.matchers import CTCMatcher
+from traccuracy.matchers._matched import Matched
+from traccuracy.metrics import (
+    AOGMMetrics,
+    BasicMetrics,
+    CellCycleAccuracy,
+    CHOTAMetric,
+    CompleteTracks,
+    CompleteTracksByLength,
+    CTCMetrics,
+    DivisionMetrics,
+    TrackOverlapMetrics,
+)
+from traccuracy.metrics._base import Metric
+
+ALL_METRIC_CLASSES = [
+    AOGMMetrics,
+    BasicMetrics,
+    CHOTAMetric,
+    CTCMetrics,
+    CellCycleAccuracy,
+    CompleteTracks,
+    CompleteTracksByLength,
+    DivisionMetrics,
+    TrackOverlapMetrics,
+]
+
+
+def _division_matched():
+    g_gt, g_pred, map_gt, map_pred = get_division_graphs()
+    mapper = list(zip(map_gt, map_pred, strict=False))
+    return Matched(TrackingGraph(g_gt), TrackingGraph(g_pred), mapper, {"name": "DummyMatcher"})
+
+
+def _ctc_matched():
+    track_graph = get_movie_with_graph(ndims=3, n_frames=3, n_labels=3)
+    return CTCMatcher().compute_mapping(gt_graph=track_graph, pred_graph=track_graph)
+
+
+def _leaf_keys(results: dict) -> set[str]:
+    """Collect the keys `_filter_sparse_safe` would classify, recursing into nested dicts."""
+    keys = set()
+    for key, value in results.items():
+        if isinstance(value, dict):
+            keys |= _leaf_keys(value)
+        else:
+            keys.add(key)
+    return keys
+
+
+# (metric factory, [(matched factory, _compute kwargs), ...]). Several metrics only emit
+# some keys under relaxed skips, so each metric lists every case needed to produce its
+# full key set, and the assertion is made against the union.
+DECLARED_KEY_CASES = [
+    pytest.param(
+        BasicMetrics,
+        [
+            (ex_graphs.all_basic_errors, {}),
+            (
+                ex_graphs.all_basic_errors,
+                {"relax_skips_gt": True, "relax_skips_pred": True},
+            ),
+        ],
+        id="BasicMetrics",
+    ),
+    pytest.param(
+        lambda: DivisionMetrics(max_frame_buffer=2),
+        [
+            (_division_matched, {}),
+            (
+                ex_graphs.div_daughter_gap,
+                {"relax_skips_gt": True, "relax_skips_pred": True},
+            ),
+        ],
+        id="DivisionMetrics",
+    ),
+    pytest.param(
+        lambda: CompleteTracks(error_type="basic"),
+        [(larger_example_1, {})],
+        id="CompleteTracks-basic",
+    ),
+    pytest.param(
+        lambda: CompleteTracks(error_type="ctc"),
+        [(larger_example_1, {})],
+        id="CompleteTracks-ctc",
+    ),
+    pytest.param(
+        lambda: CompleteTracksByLength(max_length=2),
+        [(larger_example_1, {})],
+        id="CompleteTracksByLength",
+    ),
+    pytest.param(
+        TrackOverlapMetrics,
+        [(ex_graphs.gap_close_gt_gap, {})],
+        id="TrackOverlapMetrics",
+    ),
+    pytest.param(CTCMetrics, [(_ctc_matched, {})], id="CTCMetrics"),
+    pytest.param(AOGMMetrics, [(_ctc_matched, {})], id="AOGMMetrics"),
+]
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Mapping is empty",
+    "ignore:Node errors already calculated",
+    "ignore:Edge errors already calculated",
+)
+@pytest.mark.parametrize(("metric_factory", "cases"), DECLARED_KEY_CASES)
+def test_declared_keys_are_actually_returned(metric_factory, cases):
+    declared = metric_factory().sparse_safe_keys | metric_factory().agnostic_keys
+
+    produced: set[str] = set()
+    for matched_factory, compute_kwargs in cases:
+        # A fresh metric and matched per case: reusing either replays error
+        # classification and warns "already calculated".
+        produced |= _leaf_keys(metric_factory()._compute(matched_factory(), **compute_kwargs))
+
+    assert declared <= produced, (
+        f"declared but never returned: {sorted(declared - produced)}. A renamed or "
+        "misspelled key is silently treated as dense-only and dropped from sparse results."
+    )
+
+
+@pytest.mark.parametrize("metric_class", ALL_METRIC_CLASSES, ids=lambda c: c.__name__)
+def test_sparse_safe_and_agnostic_are_disjoint(metric_class):
+    # A key in both sets resolves to "sparse_safe" silently, hiding the contradiction.
+    overlap = metric_class.sparse_safe_keys & metric_class.agnostic_keys
+    assert not overlap, f"{metric_class.__name__} classifies {sorted(overlap)} as both"
+
+
+def test_metrics_without_declared_keys_are_skipped_not_computed():
+    # CCA and CHOTA declare nothing, so under sparse ground truth they cannot report
+    # anything. Guards the list in the docs table against silently going stale.
+    for metric_class in (CellCycleAccuracy, CHOTAMetric):
+        assert not metric_class.sparse_safe_keys
+        assert not metric_class.agnostic_keys
+
+
+def test_every_metric_subclass_is_covered():
+    # A new Metric subclass should be added to ALL_METRIC_CLASSES so its declared keys
+    # get checked rather than silently skipped.
+    subclasses = {c for c in Metric.__subclasses__() if c.__module__.startswith("traccuracy")}
+    subclasses |= {
+        sub
+        for c in subclasses
+        for sub in c.__subclasses__()
+        if sub.__module__.startswith("traccuracy")
+    }
+    uncovered = sorted(c.__name__ for c in subclasses - set(ALL_METRIC_CLASSES))
+    assert not uncovered, f"uncovered Metric subclasses: {uncovered}"
+
+
+def test_leaf_keys_recurses():
+    assert _leaf_keys({"Frame Buffer 0": {"a": 1}, "b": 2}) == {"a", "b"}
+    assert _leaf_keys({}) == set()
+    # A list value (CompleteTracksByLength returns lists) is a leaf, not a container.
+    assert _leaf_keys({"accuracy": [1, 2]}) == {"accuracy"}
+
+
+def test_declared_keys_survive_a_real_sparse_compute():
+    # End-to-end: a graph marked sparse at construction filters down to exactly the
+    # declared keys, with no dense-only leftovers.
+    g = nx.DiGraph()
+    g.add_node(1, t=0, y=0, x=0)
+    g.add_node(2, t=1, y=0, x=0)
+    g.add_edge(1, 2)
+    gt = TrackingGraph(g.copy(), location_keys=("y", "x"), is_sparse_gt=True)
+    pred = TrackingGraph(g.copy(), location_keys=("y", "x"))
+    matched = Matched(gt, pred, [(1, 1), (2, 2)], {"matching type": "one-to-one"})
+
+    with pytest.warns(UserWarning, match="GT graph is marked is_sparse_gt=True"):
+        results = BasicMetrics().compute(matched).results
+
+    declared = BasicMetrics.sparse_safe_keys | BasicMetrics.agnostic_keys
+    assert set(results.keys()) <= declared
+    assert "Node Precision" not in results
+    assert "Node Recall" in results

--- a/tests/metrics/test_sparse_safe_keys.py
+++ b/tests/metrics/test_sparse_safe_keys.py
@@ -2,10 +2,12 @@
 
 ``sparse_safe_keys``/``agnostic_keys`` repeat result-key strings that ``_compute`` builds
 independently -- ``BasicMetrics`` composes them with f-strings and never writes them as
-literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, and
-the failure is silent: an unrecognized key is classified ``dense_only`` and quietly dropped
-from sparse results, while a declared key that no longer exists is a dead no-op. These tests
-turn both into a test failure.
+literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, so
+renaming a key on one side leaves the other a dead no-op that drops out of sparse results
+without a word. These tests turn that into a test failure.
+
+Whether a single declaration is self-consistent -- no key claimed as both sparse-safe and
+agnostic -- is checked by ``Metric.__init_subclass__`` when the class is defined, not here.
 """
 
 import networkx as nx
@@ -29,18 +31,6 @@ from traccuracy.metrics import (
     TrackOverlapMetrics,
 )
 from traccuracy.metrics._base import Metric
-
-ALL_METRIC_CLASSES = [
-    AOGMMetrics,
-    BasicMetrics,
-    CHOTAMetric,
-    CTCMetrics,
-    CellCycleAccuracy,
-    CompleteTracks,
-    CompleteTracksByLength,
-    DivisionMetrics,
-    TrackOverlapMetrics,
-]
 
 
 def _division_matched():
@@ -116,6 +106,12 @@ DECLARED_KEY_CASES = [
 ]
 
 
+# Metrics that legitimately declare no sparse-safe or agnostic keys, so there is
+# nothing for DECLARED_KEY_CASES to pin. Listing them explicitly keeps a metric that
+# simply forgot to declare anything from passing as one of these.
+KEYLESS_METRICS = frozenset({CellCycleAccuracy, CHOTAMetric})
+
+
 @pytest.mark.filterwarnings(
     "ignore:Mapping is empty",
     "ignore:Node errors already calculated",
@@ -137,40 +133,37 @@ def test_declared_keys_are_actually_returned(metric_factory, cases):
     )
 
 
-@pytest.mark.parametrize("metric_class", ALL_METRIC_CLASSES, ids=lambda c: c.__name__)
-def test_sparse_safe_and_agnostic_are_disjoint(metric_class):
-    # A key in both sets resolves to "sparse_safe" silently, hiding the contradiction.
-    overlap = metric_class.sparse_safe_keys & metric_class.agnostic_keys
-    assert not overlap, f"{metric_class.__name__} classifies {sorted(overlap)} as both"
+def _metric_subclasses(cls: type) -> set[type]:
+    """Every traccuracy Metric subclass, at any depth."""
+    found = set()
+    for sub in cls.__subclasses__():
+        if sub.__module__.startswith("traccuracy"):
+            found.add(sub)
+        found |= _metric_subclasses(sub)
+    return found
 
 
-def test_metrics_without_declared_keys_are_skipped_not_computed():
-    # CCA and CHOTA declare nothing, so under sparse ground truth they cannot report
-    # anything. Guards the list in the docs table against silently going stale.
-    for metric_class in (CellCycleAccuracy, CHOTAMetric):
-        assert not metric_class.sparse_safe_keys
-        assert not metric_class.agnostic_keys
+def test_every_metric_is_pinned_or_explicitly_keyless():
+    # Metric.__init_subclass__ already rejects a self-contradictory declaration, but
+    # nothing drags a new metric into DECLARED_KEY_CASES, so its keys would never be
+    # checked against what _compute returns -- and a metric that declares nothing at
+    # all would quietly default to dense-only. Every metric has to land in one bucket.
+    # Each DECLARED_KEY_CASES entry must be a pytest.param so .values[0] is its factory.
+    pinned = {type(param.values[0]()) for param in DECLARED_KEY_CASES}
+    unaccounted = sorted(
+        c.__name__ for c in _metric_subclasses(Metric) if c not in pinned | KEYLESS_METRICS
+    )
+    assert not unaccounted, (
+        f"neither pinned in DECLARED_KEY_CASES nor listed in KEYLESS_METRICS: {unaccounted}"
+    )
 
-
-def test_every_metric_subclass_is_covered():
-    # A new Metric subclass should be added to ALL_METRIC_CLASSES so its declared keys
-    # get checked rather than silently skipped.
-    subclasses = {c for c in Metric.__subclasses__() if c.__module__.startswith("traccuracy")}
-    subclasses |= {
-        sub
-        for c in subclasses
-        for sub in c.__subclasses__()
-        if sub.__module__.startswith("traccuracy")
-    }
-    uncovered = sorted(c.__name__ for c in subclasses - set(ALL_METRIC_CLASSES))
-    assert not uncovered, f"uncovered Metric subclasses: {uncovered}"
-
-
-def test_leaf_keys_recurses():
-    assert _leaf_keys({"Frame Buffer 0": {"a": 1}, "b": 2}) == {"a", "b"}
-    assert _leaf_keys({}) == set()
-    # A list value (CompleteTracksByLength returns lists) is a leaf, not a container.
-    assert _leaf_keys({"accuracy": [1, 2]}) == {"accuracy"}
+    # The other direction: a metric listed as keyless that starts declaring keys would
+    # keep being waved through above while its keys went unpinned.
+    gained = sorted(c.__name__ for c in KEYLESS_METRICS if c.sparse_safe_keys or c.agnostic_keys)
+    assert not gained, (
+        f"listed in KEYLESS_METRICS but now declares keys, so it needs a "
+        f"DECLARED_KEY_CASES entry instead: {gained}"
+    )
 
 
 def test_declared_keys_survive_a_real_sparse_compute():

--- a/tests/metrics/test_track_overlap_metrics.py
+++ b/tests/metrics/test_track_overlap_metrics.py
@@ -28,6 +28,19 @@ def test_overlap_relax_warning():
     assert results["track_fractions"] == 1
 
 
+def test_sparse_only_filters_track_purity():
+    # track_purity penalizes correctly-predicted-but-unannotated tracklets
+    # (dense-only); target_effectiveness/track_fractions only score annotated
+    # ground truth, so they remain valid on sparse ground truth.
+    matched = ex_graphs.gap_close_gt_gap()
+    metric = TrackOverlapMetrics()
+
+    results = metric.compute(matched, sparse_only=True).results
+    assert "target_effectiveness" in results
+    assert "track_fractions" in results
+    assert "track_purity" not in results
+
+
 class TestStandardOverlapMetrics:
     tp = "track_purity"
     te = "target_effectiveness"

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -1,3 +1,4 @@
+import copy
 import re
 from collections import Counter
 
@@ -265,6 +266,29 @@ def test_constructor_validate_false(nx_comp1):
     # If validation off, then it should raise another rando error
     with pytest.raises(Exception):  # noqa: B017
         TrackingGraph(nx_comp1, validate=False)
+
+
+def test_is_sparse_gt_defaults_false(nx_comp1):
+    assert TrackingGraph(nx_comp1).is_sparse_gt is False
+
+
+def test_is_sparse_gt_set_by_constructor(nx_comp1):
+    assert TrackingGraph(nx_comp1, is_sparse_gt=True).is_sparse_gt is True
+
+
+def test_is_sparse_gt_is_read_only(nx_comp1):
+    # Sparseness describes the annotations, so flipping it after construction would
+    # silently change the meaning of results already computed from this graph.
+    tg = TrackingGraph(nx_comp1, is_sparse_gt=True)
+    with pytest.raises(AttributeError):
+        tg.is_sparse_gt = False
+    assert tg.is_sparse_gt is True
+
+
+def test_is_sparse_gt_survives_deepcopy(nx_comp1):
+    # traccuracy.utils.correct_shifted_divisions deepcopies the matched graphs.
+    tg = copy.deepcopy(TrackingGraph(nx_comp1, is_sparse_gt=True))
+    assert tg.is_sparse_gt is True
 
 
 def test_validate_node():


### PR DESCRIPTION
## Summary

This PR will replace #356 if everyone is happy with it. That PR classifies sparse-ground-truth validity with one `supports_sparse_gt: bool` per `Metric` class. Working through the existing metrics turned up several where a single `_compute()` call mixes sparse-safe and dense-only outputs -- a class-level flag can't express that:

- `DivisionMetrics` returns a sparse-safe `Division Recall` alongside a dense-only `Division Precision` from the same call.
- `TrackOverlapMetrics` returns sparse-safe `target_effectiveness`/`track_fractions` alongside dense-only `track_purity`.
- `BasicMetrics` mixes sparse-safe TP/FN/recall counts with dense-only FP/precision/F1 counts, per node and edge.

This PR reworks the capability marker to classify **per result key** instead:

- `Metric.sparse_safe_keys` / `Metric.agnostic_keys`: class-level sets a metric uses to opt in specific output keys. `agnostic_keys` covers raw counts (e.g. `Total GT Nodes`) that are accurate regardless of annotation density but aren't themselves a quality judgment -- neither "safe" nor "unsafe". Anything not listed in either set defaults to dense-only (the previous default posture, preserved).
- `Metric._classify_sparse_safe(key)`: classifies a single key as `"sparse_safe"`, `"agnostic"`, or `"dense_only"`.
- `Metric.compute(..., sparse_only=True)`: filters a metric's results down to its sparse-safe/agnostic keys, recursing into nested per-key structures (e.g. `DivisionMetrics`' per-frame-buffer buckets) rather than misclassifying the bucket key itself. If filtering leaves nothing (e.g. `CTCMetrics`, whose errors are already collapsed into single dense-only scores), it warns instead of silently returning `{}`.
- `sparse_safe_keys`/`agnostic_keys` surface (as sorted tuples) in `Results.metric_info`, same JSON-serializable pattern as the original PR.

Docs updated with a per-metric breakdown table of sparse-safe/agnostic keys, replacing the class-level Yes/No column.

Closes #333 by adding a is_sparse_gt flag to the TrackingGraph. Metrics check that flag in compute and set sparse_only accordingly if it's not already set.

## Test plan

- [x] `pixi run test tests/metrics/` -- 381 passed
- [x] Full suite: 697 passed (1 pre-existing, unrelated `test_geff.py` failure)
- [x] `ruff check`, `mypy` clean
- [x] Per-metric end-to-end tests via `compute(sparse_only=True)`: flat-dict filtering (`test_basic.py`), nested frame-buffer filtering (`test_divisions.py`), dense-only-subset filtering (`test_track_overlap_metrics.py`), the "no safe keys at all" warning case (`test_ctc_metrics.py`), and the "nothing filtered" no-op case (`test_complete_tracks.py`, `test_complete_tracks_by_length.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)