### PR TITLE
Immutable is_sparse_gt, loader support, and tighten the sparse-key mechanism

### DIFF
--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -14,8 +14,8 @@ they can accept, and a brief description of behavior and any hyperparameters.
 
 Many metrics support relaxing skip edges for the ground truth and/or the prediction. Relaxing a skip edge means allowing one edge that spans multiple frames to match multiple edges in the other graph, thus potentially reducing the number of errors.
 
- Metric category | Matching Type(s) | Description |
-------------------|------------------|-------------
+| Metric category | Matching Type(s) | Description |
+|------------------|------------------|-------------|
 | [Basic Metrics](basic-metrics): TP, FP, and FN nodes and edges | `one-to-one`  | Counts the number of **true positive** (matched) nodes and edges, **false positive** (unmatched in the prediction) nodes and edges, and **false negative** (unmatched in the ground truth) nodes and edges. |
 | [Division metrics](division-metrics): TP, FP, and FN divisions and F1 score/Branching Correctness (BC) | `one-to-one` | Counts the number of **true positive** (matched) divisions, **false positive** (unmatched in the prediction) divisions, and **false negative** (unmatched in the ground truth) divisions. Then computes the division **F1-Score**, also called **Branching Correctness** by the CTC-Bio metrics. Has a `max_frame_buffer` parameter that allows counting divisions as correct within `max_frame_buffer` frames as long as the parent and children match within the buffer| 
 | [CTC Metrics](ctc-metrics): DET, LNK, TRA | `one-to-one`, `many-to-one` | A set of three metrics between 0 and 1, with higher scores indicating better performance. DET measures node errors, LNK measures linking errors, and TRA combines detection and linking errors. |
@@ -36,9 +36,25 @@ Each `Metric` classifies every key in the dictionary it returns, via `Metric._cl
 - **agnostic**: a raw count or other value that is not itself a quality judgment (e.g. `Total GT Nodes`). Accurate regardless of annotation density, so no claim is made either way.
 - **dense-only** (the default for any key not listed above): counts or derives from unmatched predictions (false positives, precision, F1, ...) and will over-penalize correct predictions of unannotated ground truth.
 
+Sparseness is a property of the annotations rather than a per-run choice, so it is declared on
+the ground truth graph itself and is read-only after construction. Pass `is_sparse_gt=True` to
+{class}`~traccuracy.TrackingGraph` or to any loader (`load_ctc_data`, `load_geff_data`,
+`load_napari_data`, `load_point_data`), and every metric computed against that graph
+restricts itself to sparse-safe and agnostic keys:
+
+```python
+gt = load_ctc_data("path/to/gt", is_sparse_gt=True)
+```
+
 :::{note}
-`Metric.compute` has a `sparse_safe` option which can be set to True in order to return only sparse safe results.
+`Metric.compute` also takes a `sparse_only` option, for filtering against a graph that was not
+marked sparse at construction. A graph marked `is_sparse_gt=True` always filters, regardless of
+this option.
 :::
+
+A metric that declares no sparse-safe or agnostic keys at all (CCA, CHOTA) cannot report
+anything under sparse ground truth. Those are skipped with a warning rather than computed and
+discarded.
 
 Sparse-safe and agnostic keys by metric (everything else that metric returns is dense-only):
 
@@ -46,7 +62,7 @@ Sparse-safe and agnostic keys by metric (everything else that metric returns is 
 |---|---|---|
 | [Basic Metrics](basic-metrics) | `True/False Negative {Nodes,Edges}`, `{Node,Edge} Recall`, `Skip GT/Pred True Positive Edges`, `Skip False Negative Edges` | `Total GT/Pred {Nodes,Edges}` |
 | [Division metrics](division-metrics) | `Division Recall`, `True/False Negative Divisions`, `Wrong Children Divisions`, `True Positive Skip Divisions` | `Total GT Divisions`, `Total Predicted Divisions` |
-| [CTC Metrics](ctc-metrics) | none | none |
+| [CTC Metrics](ctc-metrics) | `fn_nodes`, `fn_edges` | none |
 | [Cell Cycle Accuracy (CCA)](cca) | none | none |
 | [Complete Tracklets and Lineages](complete-tracks) | `correct_lineages`, `correct_tracklets`, `complete_lineages`, `complete_tracklets` | `total_lineages`, `total_tracklets` |
 | [Track Overlap Metrics](track-overlap-metrics) | `target_effectiveness`, `track_fractions` | none |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,9 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:Numba not installed, falling back to slower:UserWarning",
+    # skan calls skimage.util.map_array, which still sets .shape on an ndarray. Raised by
+    # NumPy >= 2.5 and only fixable upstream; reached from CellCycleAccuracy via skan.
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 addopts = ["--benchmark-min-rounds=1"]
 pythonpath = [

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -147,8 +147,6 @@ class TrackingGraph:
             the node. Defaults to "t".
         location_keys: tuple of str | str | None
             Key(s) used to access the location of the cell in space.
-        is_sparse_gt: bool
-            Whether this is ground truth with sparse annotations. Read-only.
     """
 
     def __init__(

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -147,6 +147,8 @@ class TrackingGraph:
             the node. Defaults to "t".
         location_keys: tuple of str | str | None
             Key(s) used to access the location of the cell in space.
+        is_sparse_gt: bool
+            Whether this is ground truth with sparse annotations. Read-only.
     """
 
     def __init__(
@@ -200,8 +202,11 @@ class TrackingGraph:
                 ``segmentation`` and ``location_keys`` (as a tuple) to be provided.
                 Defaults to None (no filtering).
             is_sparse_gt (bool, optional): If set to True, denotes that this is a ground truth
-                graph with sparse annotations. This flag will be detected by Metrics and used to
-                set the `sparse_only` flag during metric computatation.
+                graph with sparse annotations, i.e. only a subset of the real objects are
+                annotated. This flag will be detected by Metrics and used to set the
+                `sparse_only` flag during metric computation. Read-only after construction,
+                since it describes the annotations rather than a per-run choice.
+                Defaults to False.
         """
         if segmentation is not None and segmentation.dtype.kind not in ["i", "u"]:
             raise TypeError(f"Segmentation must have integer dtype, found {segmentation.dtype}")
@@ -230,7 +235,7 @@ class TrackingGraph:
         self.location_keys = location_keys
         self.name = name
         self.border_margin = border_margin
-        self.is_sparse_gt = is_sparse_gt
+        self._is_sparse_gt = is_sparse_gt
 
         self.graph = graph
 
@@ -423,6 +428,20 @@ class TrackingGraph:
             "TrackingGraph edges must go strictly forward in time (no "
             "self-loops or cycles)."
         )
+
+    @property
+    def is_sparse_gt(self) -> bool:
+        """Whether this graph is ground truth with sparse annotations.
+
+        Read-only: sparseness describes the annotations, so flipping it after
+        construction would silently change the meaning of any results already
+        computed from this graph. Pass ``is_sparse_gt`` to the constructor or to a
+        loader instead.
+
+        Returns:
+            bool: True if only a subset of the real objects are annotated.
+        """
+        return self._is_sparse_gt
 
     @property
     def nodes(self) -> NodeView:

--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -240,6 +240,7 @@ def load_ctc_data(
     name: str | None = None,
     run_checks: bool = True,
     border_margin: float | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Read the CTC segmentations and track file and create a TrackingGraph.
 
@@ -253,6 +254,10 @@ def load_ctc_data(
         border_margin (float, optional): If set, nodes whose centroid is within this
             distance (in pixels) of the spatial border will be excluded from the graph.
             Defaults to None (no filtering).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
 
     Returns:
         traccuracy.TrackingGraph: TrackingGraph object containing segmentations and graph.
@@ -301,5 +306,10 @@ def load_ctc_data(
         loc_keys = ("y", "x")
 
     return TrackingGraph(
-        G, segmentation=masks, name=name, location_keys=loc_keys, border_margin=border_margin
+        G,
+        segmentation=masks,
+        name=name,
+        location_keys=loc_keys,
+        border_margin=border_margin,
+        is_sparse_gt=is_sparse_gt,
     )

--- a/src/traccuracy/loaders/_geff.py
+++ b/src/traccuracy/loaders/_geff.py
@@ -21,6 +21,7 @@ def load_geff_data(
     name: str | None = None,
     load_all_props: bool = False,
     border_margin: float | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load a graph into memory from a geff file
 
@@ -46,6 +47,10 @@ def load_geff_data(
         border_margin (float, optional): If set, nodes whose centroid is within this
             distance (in pixels) of the spatial border will be excluded from the graph.
             Requires segmentation to be loaded. Defaults to None (no filtering).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
     """
     if load_geff_seg and seg_path is not None:
         raise ValueError('Please specify either load_geff_seg=True or seg_path="path/to/seg.zarr"')
@@ -128,4 +133,5 @@ def load_geff_data(
         location_keys=tuple(spatial_props),
         name=name,
         border_margin=border_margin,
+        is_sparse_gt=is_sparse_gt,
     )

--- a/src/traccuracy/loaders/_napari.py
+++ b/src/traccuracy/loaders/_napari.py
@@ -138,6 +138,7 @@ def load_napari_data(
     seg_id_key: str | None = None,
     name: str | None = None,
     progbar_class: type[tqdm] = tqdm,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load a napari Tracks layer into a TrackingGraph.
 
@@ -244,6 +245,10 @@ def load_napari_data(
             implicit-matching loop. Pass e.g. ``napari.utils.progress`` to show
             the bar in napari's activity dock; defaults to plain ``tqdm``
             (terminal).
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on
+            sparse ground truth. Defaults to False.
 
     Raises:
         ValueError: data does not have shape (N, 2 + D) with D in {2, 3}.
@@ -374,5 +379,12 @@ def load_napari_data(
             location_keys=location_keys,
             label_key="segmentation_id",
             name=name,
+            is_sparse_gt=is_sparse_gt,
         )
-    return TrackingGraph(G, frame_key=frame_key, location_keys=location_keys, name=name)
+    return TrackingGraph(
+        G,
+        frame_key=frame_key,
+        location_keys=location_keys,
+        name=name,
+        is_sparse_gt=is_sparse_gt,
+    )

--- a/src/traccuracy/loaders/_point.py
+++ b/src/traccuracy/loaders/_point.py
@@ -17,6 +17,7 @@ def load_point_data(
     seg_id_column: str | None = None,
     name: str | None = None,
     sep: str | None = None,
+    is_sparse_gt: bool = False,
 ) -> TrackingGraph:
     """Load point-based tracking data into a TrackingGraph from a csv-like file
 
@@ -43,6 +44,10 @@ def load_point_data(
             label id. Defaults to None.
         name (str | None, optional): Optional string to name/describe the dataset. Defaults to None.
         sep (str | None, optional): Passed to pd.read_csv to set the sep kwarg. Defaults to None.
+        is_sparse_gt (bool, optional): Set to True if this is ground truth with sparse
+            annotations, i.e. only a subset of the real objects are annotated. Metrics
+            detect this flag and restrict their results to keys that stay valid on sparse
+            ground truth. Defaults to False.
 
     Raises:
         ValueError: Must provide either a path or a dataframe
@@ -108,6 +113,17 @@ def load_point_data(
 
     if seg_id_column:
         return TrackingGraph(
-            G, frame_key=time_column, location_keys=pos_columns, label_key=seg_id_column, name=name
+            G,
+            frame_key=time_column,
+            location_keys=pos_columns,
+            label_key=seg_id_column,
+            name=name,
+            is_sparse_gt=is_sparse_gt,
         )
-    return TrackingGraph(G, frame_key=time_column, location_keys=pos_columns, name=name)
+    return TrackingGraph(
+        G,
+        frame_key=time_column,
+        location_keys=pos_columns,
+        name=name,
+        is_sparse_gt=is_sparse_gt,
+    )

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -17,13 +17,6 @@ if TYPE_CHECKING:
 MATCHING_TYPES = ["one-to-one", "one-to-many", "many-to-one", "many-to-many"]
 
 
-def _is_empty_result(results: dict) -> bool:
-    """True if `results` has no leaf values, recursing into nested dicts."""
-    if not results:
-        return True
-    return all(isinstance(v, dict) and _is_empty_result(v) for v in results.values())
-
-
 class Metric(ABC):
     """The base class for Metrics
 
@@ -162,7 +155,11 @@ class Metric(ABC):
                 graph have an equivalent multi-edge path in predicted graph
             relax_skips_pred (bool): If True, the metric will check if skips in the predicted
                 graph have an equivalent multi-edge path in ground truth graph
-            sparse_only (bool): If True, returns only metrics that are valid on sparse ground truth
+            sparse_only (bool): If True, returns only metrics that are valid on sparse ground
+                truth. A ``matched.gt_graph`` constructed with ``is_sparse_gt=True`` forces this
+                on regardless, since sparseness is a property of the annotations. If the metric
+                declares no sparse-safe or agnostic keys at all it cannot report anything, so
+                ``_compute`` is skipped and an empty result is returned with a warning.
 
         Returns:
             traccuracy.metrics._results.Results: Object containing metric results
@@ -182,13 +179,8 @@ class Metric(ABC):
                     "of the metric. Check the documentation for the metric for more information."
                 )
 
-        _res_dict = self._compute(
-            matched,
-            relax_skips_gt=relax_skips_gt,
-            relax_skips_pred=relax_skips_pred,
-        )
-
-        # Check if the ground truth graph has the sparse flag set
+        # Sparseness is a property of the annotations, not a per-run choice, so a GT graph
+        # marked sparse forces filtering on.
         if matched.gt_graph.is_sparse_gt and not sparse_only:
             sparse_only = True
             warnings.warn(
@@ -196,17 +188,25 @@ class Metric(ABC):
                 stacklevel=2,
             )
 
-        if sparse_only:
-            res_dict = self._filter_sparse_safe(_res_dict)
-            if _is_empty_result(res_dict):
-                warnings.warn(
-                    f"{type(self).__name__} has no sparse-safe or agnostic keys, so "
-                    "sparse_only=True filtered every result out. This metric is not "
-                    "meaningful on sparse ground truth.",
-                    stacklevel=2,
-                )
+        # Whether anything can survive filtering is a class-level property, so answer it
+        # before paying for _compute instead of computing and discarding everything.
+        res_dict: dict
+        if sparse_only and not (type(self).sparse_safe_keys | type(self).agnostic_keys):
+            warnings.warn(
+                f"{type(self).__name__} has no sparse-safe or agnostic keys, so "
+                "sparse_only=True filtered every result out. This metric is not "
+                "meaningful on sparse ground truth.",
+                stacklevel=2,
+            )
+            res_dict = {}
         else:
-            res_dict = _res_dict
+            res_dict = self._compute(
+                matched,
+                relax_skips_gt=relax_skips_gt,
+                relax_skips_pred=relax_skips_pred,
+            )
+            if sparse_only:
+                res_dict = self._filter_sparse_safe(res_dict)
 
         run_info = self.info
         run_info["relax_skips_gt"] = relax_skips_gt

--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -35,6 +35,12 @@ class AOGMMetrics(Metric):
         edge_ws_weight (float): Weight for wrong semantic edge errors. Defaults to 1
     """
 
+    # The false negative counts are read off the ground truth graph, so they only judge
+    # objects the annotation covers and hold on sparse ground truth. AOGM itself (and the
+    # TRA/DET/LNK scores derived from it in CTCMetrics) sums in the false-positive,
+    # non-split and wrong-semantic terms, so those stay dense-only.
+    sparse_safe_keys = frozenset({"fn_nodes", "fn_edges"})
+
     def __init__(
         self,
         vertex_ns_weight: float = 1,

--- a/tests/loaders/test_ctc.py
+++ b/tests/loaders/test_ctc.py
@@ -116,6 +116,16 @@ def test_load_data():
     assert len(track_data.segmentation) == 92
 
 
+def test_load_data_is_sparse_gt():
+    test_dir = os.path.abspath(__file__)
+    data_dir = os.path.abspath(
+        os.path.join(test_dir, "../../../examples/sample-data/Fluo-N2DL-HeLa/01_RES/")
+    )
+    track_path = os.path.join(data_dir, "res_track.txt")
+    assert _ctc.load_ctc_data(data_dir, track_path).is_sparse_gt is False
+    assert _ctc.load_ctc_data(data_dir, track_path, is_sparse_gt=True).is_sparse_gt is True
+
+
 def test_load_data_no_track_path():
     test_dir = os.path.abspath(__file__)
     data_dir = os.path.abspath(

--- a/tests/loaders/test_geff.py
+++ b/tests/loaders/test_geff.py
@@ -38,6 +38,18 @@ class Test_load_geff_data:
         tg = load_geff_data(zarr_path, load_all_props=True)
         assert "score" in tg.graph.edges[(0, 1)]
 
+    def test_is_sparse_gt(self, tmp_path):
+        zarr_path = tmp_path / "test.zarr"
+        store, _ = create_simple_2d_geff(directed=True)
+        graph, meta = read(store, backend="networkx")
+        time_key = next(ax.name for ax in meta.axes if ax.type == "time")
+        for node in graph.nodes:
+            graph.nodes[node][time_key] = float(node)
+        write(graph, zarr_path, meta)
+
+        assert load_geff_data(zarr_path).is_sparse_gt is False
+        assert load_geff_data(zarr_path, is_sparse_gt=True).is_sparse_gt is True
+
     def test_undirected(self, tmp_path):
         zarr_path = tmp_path / "test.zarr"
         store, _ = create_simple_2d_geff(directed=False)

--- a/tests/loaders/test_napari.py
+++ b/tests/loaders/test_napari.py
@@ -19,6 +19,17 @@ class Test_load_napari_data:
         assert first["t"] == 0 and isinstance(first["t"], int)
         assert first["y"] == 10 and first["x"] == 20
 
+    def test_is_sparse_gt(self):
+        data = np.array([[1, 0, 10, 20], [1, 1, 11, 21]], dtype=float)
+        assert load_napari_data(data).is_sparse_gt is False
+        assert load_napari_data(data, is_sparse_gt=True).is_sparse_gt is True
+        # The segmentation branch constructs a separate TrackingGraph.
+        seg = np.zeros((2, 30, 30), dtype=np.uint16)
+        seg[0, 9:12, 19:22] = 1
+        seg[1, 10:13, 20:23] = 1
+        tg = load_napari_data(data, segmentation=seg, is_sparse_gt=True)
+        assert tg.is_sparse_gt is True
+
     def test_3d_locations(self):
         data = np.array([[1, 0, 3, 4, 5], [1, 1, 3, 4, 5]], dtype=float)
         tg = load_napari_data(data)

--- a/tests/loaders/test_point.py
+++ b/tests/loaders/test_point.py
@@ -77,6 +77,15 @@ class Test_load_point_data:
         ):
             load_point_data(df=df, name="test")
 
+    def test_is_sparse_gt(self):
+        df = self.get_valid_df(5)
+        assert load_point_data(df=df).is_sparse_gt is False
+        assert load_point_data(df=df, is_sparse_gt=True).is_sparse_gt is True
+        # The seg_id_column branch constructs a separate TrackingGraph.
+        df_seg = df.assign(seg_label=range(5))
+        graph = load_point_data(df=df_seg, seg_id_column="seg_label", is_sparse_gt=True)
+        assert graph.is_sparse_gt is True
+
     def test_load_from_dataframe(self):
         # Make a valid dataframe using defaults
         nrows = 5

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -1,3 +1,5 @@
+import warnings
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -187,12 +189,17 @@ class TestMetric:
         assert results.metric_info["sparse_safe_keys"] == ("safe_key",)
         assert results.metric_info["agnostic_keys"] == ("neutral_key",)
 
-    def test_sparse_only_warns_when_metric_has_no_safe_keys(self):
-        # A metric that declares no sparse-safe/agnostic keys (the default) has
-        # nothing left after filtering; sparse_only=True should say so rather than
-        # silently handing back an empty dict.
+    def test_sparse_only_skips_metric_with_no_safe_keys(self):
+        # A metric that declares no sparse-safe/agnostic keys (the default) can never
+        # report anything under sparse_only, which is knowable from the class alone --
+        # so _compute should be skipped entirely rather than computed and discarded.
         class DenseOnlyMetric(ValidMetric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.computed = False
+
             def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                self.computed = True
                 return {"dense_key": 1}
 
         matched = Matched(
@@ -201,8 +208,31 @@ class TestMetric:
             [],
             {"matching type": "one-to-one"},
         )
+        metric = DenseOnlyMetric()
         with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
-            results = DenseOnlyMetric().compute(matched, sparse_only=True)
+            results = metric.compute(matched, sparse_only=True)
+        assert results.results == {}
+        assert metric.computed is False
+
+    def test_sparse_only_does_not_warn_when_compute_is_legitimately_empty(self):
+        # An empty _compute result must not be mistaken for "this metric has no
+        # sparse-safe keys" -- e.g. CompleteTracksByLength returns {} for a graph with
+        # no frame range while declaring three sparse-safe/agnostic keys.
+        class EmptyResultMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+
+            def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                return {}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph()),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            results = EmptyResultMetric().compute(matched, sparse_only=True)
         assert results.results == {}
 
     def test_set_sparse_to_true_with_sparse_gt(self):
@@ -212,7 +242,7 @@ class TestMetric:
             agnostic_keys = frozenset({"neutral_key"})
 
             def _compute(self, matched, relax_skips_gt, relax_skips_pred):
-                return {"safe_key": 0, "neutral_key": 1}
+                return {"safe_key": 0, "neutral_key": 1, "dense_key": 2}
 
         matched = Matched(
             TrackingGraph(nx.DiGraph(), is_sparse_gt=True),
@@ -227,6 +257,27 @@ class TestMetric:
         ):
             results = MixedMetric().compute(matched)
         assert results.metric_info["sparse_only"] is True
+        # The flag actually filtered, rather than only being recorded in the metadata.
+        assert results.results == {"safe_key": 0, "neutral_key": 1}
+
+    def test_explicit_sparse_only_false_does_not_override_sparse_gt(self):
+        # Sparseness describes the annotations, so the graph flag wins over the kwarg.
+        class MixedMetric(ValidMetric):
+            sparse_safe_keys = frozenset({"safe_key"})
+
+            def _compute(self, matched, relax_skips_gt=False, relax_skips_pred=False):
+                return {"safe_key": 0, "dense_key": 1}
+
+        matched = Matched(
+            TrackingGraph(nx.DiGraph(), is_sparse_gt=True),
+            TrackingGraph(nx.DiGraph()),
+            [],
+            {"matching type": "one-to-one"},
+        )
+        with pytest.warns(UserWarning, match="GT graph is marked is_sparse_gt=True"):
+            results = MixedMetric().compute(matched, sparse_only=False)
+        assert results.metric_info["sparse_only"] is True
+        assert results.results == {"safe_key": 0}
 
 
 def test_filter_sparse_safe_flat_dict():

--- a/tests/metrics/test_ctc_metrics.py
+++ b/tests/metrics/test_ctc_metrics.py
@@ -72,18 +72,18 @@ def test_compute_mapping():
     assert results["DET"] == 1
 
 
-def test_sparse_only_filters_everything():
-    # CTC/AOGM errors collapse false positives and false negatives into single
-    # inseparable scores, so no key is sparse-safe or agnostic: sparse_only
-    # filters the whole results dict down to nothing.
+def test_sparse_only_keeps_only_false_negative_counts():
+    # The fn counts are read off the gt graph so they survive sparse filtering, but
+    # AOGM and the TRA/DET/LNK scores derived from it fold in the fp/ns/ws terms and
+    # are dropped.
     n_frames = 3
     n_labels = 3
     track_graph = get_movie_with_graph(ndims=3, n_frames=n_frames, n_labels=n_labels)
 
     matched = CTCMatcher().compute_mapping(gt_graph=track_graph, pred_graph=track_graph)
-    with pytest.warns(UserWarning, match="not meaningful on sparse ground truth"):
-        results = CTCMetrics().compute(matched, sparse_only=True).results
-    assert results == {}
+    results = CTCMetrics().compute(matched, sparse_only=True).results
+
+    assert set(results.keys()) == {"fn_nodes", "fn_edges"}
 
 
 def test_get_det():

--- a/tests/metrics/test_sparse_safe_keys.py
+++ b/tests/metrics/test_sparse_safe_keys.py
@@ -1,0 +1,193 @@
+"""Pin each metric's declared sparse-safe/agnostic keys to the keys it actually returns.
+
+``sparse_safe_keys``/``agnostic_keys`` repeat result-key strings that ``_compute`` builds
+independently -- ``BasicMetrics`` composes them with f-strings and never writes them as
+literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, and
+the failure is silent: an unrecognized key is classified ``dense_only`` and quietly dropped
+from sparse results, while a declared key that no longer exists is a dead no-op. These tests
+turn both into a test failure.
+"""
+
+import networkx as nx
+import pytest
+
+import tests.examples.graphs as ex_graphs
+from tests.examples.larger_examples import larger_example_1
+from tests.test_utils import get_division_graphs, get_movie_with_graph
+from traccuracy import TrackingGraph
+from traccuracy.matchers import CTCMatcher
+from traccuracy.matchers._matched import Matched
+from traccuracy.metrics import (
+    AOGMMetrics,
+    BasicMetrics,
+    CellCycleAccuracy,
+    CHOTAMetric,
+    CompleteTracks,
+    CompleteTracksByLength,
+    CTCMetrics,
+    DivisionMetrics,
+    TrackOverlapMetrics,
+)
+from traccuracy.metrics._base import Metric
+
+ALL_METRIC_CLASSES = [
+    AOGMMetrics,
+    BasicMetrics,
+    CHOTAMetric,
+    CTCMetrics,
+    CellCycleAccuracy,
+    CompleteTracks,
+    CompleteTracksByLength,
+    DivisionMetrics,
+    TrackOverlapMetrics,
+]
+
+
+def _division_matched():
+    g_gt, g_pred, map_gt, map_pred = get_division_graphs()
+    mapper = list(zip(map_gt, map_pred, strict=False))
+    return Matched(TrackingGraph(g_gt), TrackingGraph(g_pred), mapper, {"name": "DummyMatcher"})
+
+
+def _ctc_matched():
+    track_graph = get_movie_with_graph(ndims=3, n_frames=3, n_labels=3)
+    return CTCMatcher().compute_mapping(gt_graph=track_graph, pred_graph=track_graph)
+
+
+def _leaf_keys(results: dict) -> set[str]:
+    """Collect the keys `_filter_sparse_safe` would classify, recursing into nested dicts."""
+    keys = set()
+    for key, value in results.items():
+        if isinstance(value, dict):
+            keys |= _leaf_keys(value)
+        else:
+            keys.add(key)
+    return keys
+
+
+# (metric factory, [(matched factory, _compute kwargs), ...]). Several metrics only emit
+# some keys under relaxed skips, so each metric lists every case needed to produce its
+# full key set, and the assertion is made against the union.
+DECLARED_KEY_CASES = [
+    pytest.param(
+        BasicMetrics,
+        [
+            (ex_graphs.all_basic_errors, {}),
+            (
+                ex_graphs.all_basic_errors,
+                {"relax_skips_gt": True, "relax_skips_pred": True},
+            ),
+        ],
+        id="BasicMetrics",
+    ),
+    pytest.param(
+        lambda: DivisionMetrics(max_frame_buffer=2),
+        [
+            (_division_matched, {}),
+            (
+                ex_graphs.div_daughter_gap,
+                {"relax_skips_gt": True, "relax_skips_pred": True},
+            ),
+        ],
+        id="DivisionMetrics",
+    ),
+    pytest.param(
+        lambda: CompleteTracks(error_type="basic"),
+        [(larger_example_1, {})],
+        id="CompleteTracks-basic",
+    ),
+    pytest.param(
+        lambda: CompleteTracks(error_type="ctc"),
+        [(larger_example_1, {})],
+        id="CompleteTracks-ctc",
+    ),
+    pytest.param(
+        lambda: CompleteTracksByLength(max_length=2),
+        [(larger_example_1, {})],
+        id="CompleteTracksByLength",
+    ),
+    pytest.param(
+        TrackOverlapMetrics,
+        [(ex_graphs.gap_close_gt_gap, {})],
+        id="TrackOverlapMetrics",
+    ),
+    pytest.param(CTCMetrics, [(_ctc_matched, {})], id="CTCMetrics"),
+    pytest.param(AOGMMetrics, [(_ctc_matched, {})], id="AOGMMetrics"),
+]
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Mapping is empty",
+    "ignore:Node errors already calculated",
+    "ignore:Edge errors already calculated",
+)
+@pytest.mark.parametrize(("metric_factory", "cases"), DECLARED_KEY_CASES)
+def test_declared_keys_are_actually_returned(metric_factory, cases):
+    declared = metric_factory().sparse_safe_keys | metric_factory().agnostic_keys
+
+    produced: set[str] = set()
+    for matched_factory, compute_kwargs in cases:
+        # A fresh metric and matched per case: reusing either replays error
+        # classification and warns "already calculated".
+        produced |= _leaf_keys(metric_factory()._compute(matched_factory(), **compute_kwargs))
+
+    assert declared <= produced, (
+        f"declared but never returned: {sorted(declared - produced)}. A renamed or "
+        "misspelled key is silently treated as dense-only and dropped from sparse results."
+    )
+
+
+@pytest.mark.parametrize("metric_class", ALL_METRIC_CLASSES, ids=lambda c: c.__name__)
+def test_sparse_safe_and_agnostic_are_disjoint(metric_class):
+    # A key in both sets resolves to "sparse_safe" silently, hiding the contradiction.
+    overlap = metric_class.sparse_safe_keys & metric_class.agnostic_keys
+    assert not overlap, f"{metric_class.__name__} classifies {sorted(overlap)} as both"
+
+
+def test_metrics_without_declared_keys_are_skipped_not_computed():
+    # CCA and CHOTA declare nothing, so under sparse ground truth they cannot report
+    # anything. Guards the list in the docs table against silently going stale.
+    for metric_class in (CellCycleAccuracy, CHOTAMetric):
+        assert not metric_class.sparse_safe_keys
+        assert not metric_class.agnostic_keys
+
+
+def test_every_metric_subclass_is_covered():
+    # A new Metric subclass should be added to ALL_METRIC_CLASSES so its declared keys
+    # get checked rather than silently skipped.
+    subclasses = {c for c in Metric.__subclasses__() if c.__module__.startswith("traccuracy")}
+    subclasses |= {
+        sub
+        for c in subclasses
+        for sub in c.__subclasses__()
+        if sub.__module__.startswith("traccuracy")
+    }
+    uncovered = sorted(c.__name__ for c in subclasses - set(ALL_METRIC_CLASSES))
+    assert not uncovered, f"uncovered Metric subclasses: {uncovered}"
+
+
+def test_leaf_keys_recurses():
+    assert _leaf_keys({"Frame Buffer 0": {"a": 1}, "b": 2}) == {"a", "b"}
+    assert _leaf_keys({}) == set()
+    # A list value (CompleteTracksByLength returns lists) is a leaf, not a container.
+    assert _leaf_keys({"accuracy": [1, 2]}) == {"accuracy"}
+
+
+def test_declared_keys_survive_a_real_sparse_compute():
+    # End-to-end: a graph marked sparse at construction filters down to exactly the
+    # declared keys, with no dense-only leftovers.
+    g = nx.DiGraph()
+    g.add_node(1, t=0, y=0, x=0)
+    g.add_node(2, t=1, y=0, x=0)
+    g.add_edge(1, 2)
+    gt = TrackingGraph(g.copy(), location_keys=("y", "x"), is_sparse_gt=True)
+    pred = TrackingGraph(g.copy(), location_keys=("y", "x"))
+    matched = Matched(gt, pred, [(1, 1), (2, 2)], {"matching type": "one-to-one"})
+
+    with pytest.warns(UserWarning, match="GT graph is marked is_sparse_gt=True"):
+        results = BasicMetrics().compute(matched).results
+
+    declared = BasicMetrics.sparse_safe_keys | BasicMetrics.agnostic_keys
+    assert set(results.keys()) <= declared
+    assert "Node Precision" not in results
+    assert "Node Recall" in results

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -1,3 +1,4 @@
+import copy
 import re
 from collections import Counter
 
@@ -265,6 +266,29 @@ def test_constructor_validate_false(nx_comp1):
     # If validation off, then it should raise another rando error
     with pytest.raises(Exception):  # noqa: B017
         TrackingGraph(nx_comp1, validate=False)
+
+
+def test_is_sparse_gt_defaults_false(nx_comp1):
+    assert TrackingGraph(nx_comp1).is_sparse_gt is False
+
+
+def test_is_sparse_gt_set_by_constructor(nx_comp1):
+    assert TrackingGraph(nx_comp1, is_sparse_gt=True).is_sparse_gt is True
+
+
+def test_is_sparse_gt_is_read_only(nx_comp1):
+    # Sparseness describes the annotations, so flipping it after construction would
+    # silently change the meaning of results already computed from this graph.
+    tg = TrackingGraph(nx_comp1, is_sparse_gt=True)
+    with pytest.raises(AttributeError):
+        tg.is_sparse_gt = False
+    assert tg.is_sparse_gt is True
+
+
+def test_is_sparse_gt_survives_deepcopy(nx_comp1):
+    # traccuracy.utils.correct_shifted_divisions deepcopies the matched graphs.
+    tg = copy.deepcopy(TrackingGraph(nx_comp1, is_sparse_gt=True))
+    assert tg.is_sparse_gt is True
 
 
 def test_validate_node():


### PR DESCRIPTION
Stacked on #363 (base is `feat/sparse-gt-key-classification`, so the diff here is only my additions). Happy to squash any of this into #363 instead if that's easier, @msschwartz21 — or drop the bits you disagree with.

The per-key model in #363 is the right primitive: a class-level bool genuinely can't express `DivisionMetrics` returning a sparse-safe recall and a dense-only precision from one call. This just tightens the edges around it.

## `is_sparse_gt` is read-only, and loaders can set it

Sparseness describes the annotations, not a per-run preference — so `sparse_only=False` shouldn't be able to override it (it can't, and that's correct), and by the same logic it shouldn't be mutable after construction either. Flipping it later silently changes the meaning of results already computed from that graph. It's now backed by a private attribute behind a read-only property.

The flip side: if the graph flag is *the* route to sparse metrics, it has to be reachable where graphs are actually built. None of the loaders exposed it, so ground truth loaded the canonical way had to be patched after the fact. `is_sparse_gt` is now a parameter on `load_ctc_data`, `load_geff_data`, `load_napari_data` and `load_point_data`:

```python
gt = load_ctc_data("path/to/gt", is_sparse_gt=True)
```

I did *not* add `sparse_only` to `run_metrics`. `relax_skips_*` is a genuine analysis choice while sparseness is a data property, so the asymmetry seems right — but say the word and I'll add it.

## Applicability is decided before `_compute`, not after

Whether anything survives filtering is knowable from the class alone: if a metric declares neither set, every leaf is dense-only by construction. Moving that check ahead of `_compute` fixes three things at once.

**The "no sparse-safe keys" warning was misfiring.** It was inferred from an empty *output*, so any metric whose `_compute` legitimately returns `{}` got blamed. Reproducible on `CompleteTracksByLength`, which declares three keys:

```
WARN: GT graph has no frame range (empty graph). Returning empty results.
WARN: CompleteTracksByLength has no sparse-safe or agnostic keys, so sparse_only=True
      filtered every result out. This metric is not meaningful on sparse ground truth.
declared sparse_safe_keys: ['accuracy', 'correct'] agnostic: ['total']
```

**CCA and CHOTA no longer compute and discard.** They previously ran a full `_compute` under a sparse GT graph and then threw away 100% of it.

**`_is_empty_result` is gone** — the static check subsumes it.

Observable behaviour is unchanged: same warning, same empty results, just decided earlier. I deliberately kept it a *warning* rather than raising. #333 proposed erroring on unsupported metrics and there's a real argument for it, but that would turn a mixed `run_metrics([BasicMetrics(), CHOTAMetric()])` call on sparse ground truth into a hard failure, and that's your call rather than mine. Easy switch if you want it.

## CTC/AOGM false-negative counts are sparse-safe

You asked for a second pair of eyes on the classifications, so: `CTCMetrics(...).compute(...).results` actually returns

```
['AOGM', 'DET', 'LNK', 'TRA', 'fn_edges', 'fn_nodes', 'fp_edges', 'fp_nodes', 'ns_nodes', 'ws_edges']
```

`fn_nodes` and `fn_edges` come off `data.gt_graph` (`NodeFlag.CTC_FALSE_NEG` / `EdgeFlag.CTC_FALSE_NEG`), so they only judge objects the annotation covers — and `BasicMetrics` already declares its equivalent `False Negative Nodes`/`Edges` sparse-safe. The "already collapsed into single dense-only scores" rationale holds for TRA/DET/LNK/AOGM but not for those two raw counts, so `sparse_only=True` was dropping usable numbers and warning the metric was meaningless.

`ns_nodes` and `ws_edges` I left dense-only — they're flagged on the prediction and I wasn't confident either way.

## The declared key sets are now pinned to reality

This is the one I'd most like your opinion on, since it's about the mechanism rather than a specific classification.

`sparse_safe_keys`/`agnostic_keys` repeat result-key strings that `_compute` builds independently. `BasicMetrics` never writes `"Node Recall"` as a literal at all — it composes it via `f"{feature_type} Recall"` after `feature_type.capitalize()`. `DivisionMetrics` writes its ten keys out twice. Nothing ties any of that to the declared sets, and the failure is silent both ways: an unrecognized key is classified `dense_only` and quietly vanishes from sparse results, and a declared key that no longer exists is a dead no-op.

`tests/metrics/test_sparse_safe_keys.py` asserts `declared <= returned` per metric, unioned over the relaxed/non-relaxed cases needed to emit the conditional skip keys, plus that the two sets are disjoint and that every `Metric` subclass is covered. Verified it actually fails — renaming `"Node Recall"` to `"Nod Recall"` gives:

```
AssertionError: declared but never returned: ['Nod Recall']. A renamed or misspelled key
is silently treated as dense-only and dropped from sparse results.
```

I considered making the keys an enum like `NodeFlag`/`EdgeFlag`, or a `TypedDict` per result so mypy checks the *producing* side. Both are better guarantees, but the enum needs `BasicMetrics._compute_stats`'s f-string composition unrolled into explicit `NODE_RECALL`/`EDGE_RECALL` members, which is churn in the most-used metric and unrelated to sparse support. Feels like its own PR — and one that pays for itself on `_divisions.py`'s duplicated literals regardless.

## Docs

The note named a `sparse_safe` option; the parameter is `sparse_only`. Also documented `is_sparse_gt` as the primary route, added the loader mention, recorded CTC's fn counts in the table, and restored the leading pipe that got clipped from the metrics table header when the old warning block came out.

## One thing not addressed

#363 says "Closes #333", but #333 asks for two things and this stack delivers one. "Don't report FPs in the error counts" is done. "Weight FPs zero in the summary metrics (AOGM, TRA, CHOTA, etc.)" isn't, and filtering structurally can't deliver it — the sparse-correct TRA isn't "no TRA", it's TRA computed with `vertex_fp_weight=0`, which is a change to the computation rather than to which keys come back. `AOGMMetrics` already takes those weights as constructor args so the path is unusually short, though whether a reweighted TRA should still be called TRA is a real question. Suggest `Refs #333` and leaving it open.

## Test plan

- `pytest` — **730 passed**, 0 failures (`pixi -e dev`, py3.11 linux). Includes 33 new tests. Note I did not reproduce the pre-existing `test_geff.py` failure mentioned in #363.
- `ruff check src tests` and `ruff format --check` — clean.
- `mypy src/traccuracy` — 3 errors, all pre-existing in `_cca.py` / `_compute_overlap.py`, none in changed files.
- Mutation-checked the new contract test as shown above.

## CI

Two follow-up commits here, plus one thing that can't be fixed from this PR.

- **`fix(docs)`** — mine. I had documented `is_sparse_gt` both as a `@property` and in the class docstring's `Attributes:` list, so autoapi emitted a duplicate object description and Read the Docs (which runs sphinx with `-W`) failed. The property keeps its own docstring; `nodes`/`edges` are handled the same way and are deliberately absent from that list. Duplicate-object warnings 2 → 0 locally, and RTD is green again.
- **`test: ignore the NumPy 2.5 shape deprecation raised via skan`** — **not related to this PR's subject.** `skan` calls `skimage.util.map_array`, which still assigns to `ndarray.shape`; NumPy >= 2.5 deprecates it and `filterwarnings = ["error"]` turns it into 2 failures in `test_cca.py` and 2 in `bench.py`. Only visible on py3.12/3.13 because the resolver picks NumPy 2.5 there. It breaks `main` equally — main's last green run predates the NumPy 2.5 release — so it's dependency drift, not a code change. With it, the entire 3.12/3.13 matrix went green.
- **Benchmark stays red until #365 merges.** The job does `git checkout ${{ github.event.pull_request.base.sha }}` and benchmarks the *base* commit, which doesn't carry the ignore, and the cache key is the base SHA so it re-fails every run. It's structurally unfixable from this branch. I opened #365 against `main` with just that one commit; once it lands (and this branch's base picks it up) Benchmark should pass. Happy to drop the duplicate commit from here and rebase at that point.
