### PR TITLE
Ignore the NumPy 2.5 shape deprecation raised via skan (fixes red CI on main)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,9 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:Numba not installed, falling back to slower:UserWarning",
+    # skan calls skimage.util.map_array, which still sets .shape on an ndarray. Raised by
+    # NumPy >= 2.5 and only fixable upstream; reached from CellCycleAccuracy via skan.
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 addopts = ["--benchmark-min-rounds=1"]
 pythonpath = [


### PR DESCRIPTION
CI is currently red on `main` for reasons unrelated to any code change — this is NumPy 2.5 dependency drift, and it needs to land here rather than in a feature branch.

## What breaks

`skan` calls `skimage.util.map_array`, which still assigns to `ndarray.shape`. NumPy >= 2.5 deprecates that, and since pytest is configured with `filterwarnings = ["error"]` the warning fails four tests:

```
FAILED tests/metrics/test_cca.py::TestCellCycleAccuracy::test_get_subgraph_lengths
FAILED tests/metrics/test_cca.py::TestCellCycleAccuracy::test_compute
FAILED tests/bench.py::test_cca_metric[2d]
FAILED tests/bench.py::test_cca_metric[3d]
```

It only shows on py3.12/3.13 because the resolver picks NumPy 2.5 there; 3.10 and 3.11 still get an older NumPy. That's why this looks like a version-specific bug and isn't one. `main`'s last green run predates the NumPy 2.5 release, so nothing in the repo changed — any PR opened today fails the 3.12/3.13 matrix jobs and the Benchmark job.

The only path is through `CellCycleAccuracy` → `skan` → `skimage`, so it isn't fixable in this repo. Ignoring it matches the existing numba ignore directly above.

## Why it has to land on main

The Benchmark job does:

```yaml
- name: Run baseline benchmark if not in cache
  run: |
    git checkout ${{ github.event.pull_request.base.sha }}
    pytest tests/bench.py -v --benchmark-json baseline.json
```

It checks out the PR's **base** commit and benchmarks that. So a PR that carries the fix still fails Benchmark, because the baseline run happens on a commit without it — and the cache key is the base SHA, so it re-runs and re-fails every time. Confirmed on #364, where the whole 3.12/3.13 matrix went green with this change but Benchmark stayed red.

## Verification

A/B on this branch's code in a fresh py3.12 env (NumPy 2.5.2, skan 0.13.1, skimage 0.26.0):

- `pyproject.toml` from `main` (no ignore): `2 failed, 1 passed` in `tests/metrics/test_cca.py` — exactly the tests CI reports.
- With the ignore: `3 passed`.
- Full suite on this branch: **683 passed, 1 skipped**.

## Note

The same commit is currently also on #364 so that its own test matrix passes. Once this merges, that one is a duplicate — trivially resolved (identical lines), or I can drop it from #364 and rebase.

## About the one red check on this PR

Benchmark is red here too, and it will stay red until this merges. That's the same mechanism described above, not a defect in the fix: the only step that failed is **"Run baseline benchmark if not in cache"**, which does `git checkout <base.sha>` and runs `tests/bench.py` against `main` — a commit that by definition doesn't contain this fix. The "Run benchmark on PR head commit" step never executed. Every other check passes, including the whole 3.12/3.13 matrix that was failing.

So the ordering is: merge this → `main`'s baseline becomes clean → Benchmark goes green for #364 and every subsequent PR. No PR can make it green beforehand.

If you'd rather it not be red pre-merge, two options, neither of which I wanted to make unilaterally:

1. **Have the baseline step keep the PR's test config**, e.g. `git checkout <base.sha> -- src tests` instead of a full checkout. The baseline then measures base's *code* under the PR's pytest config, which is arguably more correct for a comparison anyway (identical config on both sides), and makes fixes like this one self-applying.
2. **Constrain `numpy` in the `test` extra.** `pip install -e .[test]` runs *before* the base checkout, so the installed NumPy comes from the PR head regardless of which `pyproject.toml` is checked out afterwards — a `numpy<2.5` pin would therefore fix the baseline step immediately. But `numpy` is an unpinned runtime dependency, so this constrains real environments and will rot once skan/skimage fix things upstream. I'd prefer the ignore.
