### PR TITLE
Validate declared sparse-safe/agnostic keys at class definition

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_matcher_metric.md
@@ -14,7 +14,7 @@ Put an x in the boxes that apply. You can also fill these out after creating the
 - [ ] I have added a page to the documentation with a complete description of my matcher/metric including any references.
 - [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
 - [ ] For a new metric, I have specified `sparse_safe_keys`, `agnostic_keys` and `_sparse_inflatable_substrings` in the Metric definition.
-- [ ] For a new metric, I have added it to `ALL_METRIC_CLASSES` in tests/metrics/test_sparse_safe_keys.py
+- [ ] For a new metric, I have added a `DECLARED_KEY_CASES` entry in tests/metrics/test_sparse_safe_keys.py, or listed it in `KEYLESS_METRICS` there if it has no sparse-safe or agnostic keys
 
 # Further Comments
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -41,12 +41,48 @@ class Metric(ABC):
     - Anything not listed in either set is treated as dense-only: it counts or
       derives from unmatched predictions (false positives, precision, F1, ...) and
       will over-penalize correct predictions of unannotated ground truth.
+
+    The two sets must be disjoint frozensets; ``__init_subclass__`` checks that when
+    the subclass is defined.
     """
 
     #: See the "sparse-safe" bullet in the class docstring.
     sparse_safe_keys: frozenset[str] = frozenset()
     #: See the "agnostic" bullet in the class docstring.
     agnostic_keys: frozenset[str] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Check a subclass's declared key sets when the class is defined.
+
+        Runs at class definition rather than on instantiation, so a contradictory
+        declaration fails on import instead of lurking in a metric that a given run
+        never happens to instantiate.
+
+        Args:
+            **kwargs: Forwarded to ``super().__init_subclass__``.
+
+        Raises:
+            TypeError: Either declaration is not a frozenset.
+            ValueError: A key is declared both sparse-safe and agnostic.
+        """
+        super().__init_subclass__(**kwargs)
+        for name in ("sparse_safe_keys", "agnostic_keys"):
+            declared = getattr(cls, name)
+            if not isinstance(declared, frozenset):
+                raise TypeError(
+                    f"{cls.__name__}.{name} must be a frozenset, got "
+                    f"{type(declared).__name__}. Declared key sets are immutable so "
+                    "they cannot be edited into an overlap in place after this check "
+                    "runs; rebinding the attribute later is still unchecked."
+                )
+        overlap = cls.sparse_safe_keys & cls.agnostic_keys
+        if overlap:
+            raise ValueError(
+                f"{cls.__name__} declares {sorted(overlap)} as both sparse-safe and "
+                "agnostic (either side may be inherited). _classify_sparse_safe "
+                "resolves such a key to sparse-safe and the contradiction goes "
+                "unnoticed, so put each key in exactly one set."
+            )
 
     def __init__(self, valid_matches: list, zero_division: float = np.nan):
         """Initialize metric.

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -173,6 +173,34 @@ class TestMetric:
         assert m._classify_sparse_safe("neutral_key") == "agnostic"
         assert m._classify_sparse_safe("other_key") == "dense_only"
 
+    def test_overlapping_key_sets_raise_at_class_definition(self):
+        # Caught when the class is defined, so a bad declaration cannot hide in a
+        # metric that a given run never instantiates.
+        with pytest.raises(ValueError, match="both sparse-safe and agnostic"):
+
+            class ContradictoryMetric(ValidMetric):
+                sparse_safe_keys = frozenset({"shared_key", "safe_key"})
+                agnostic_keys = frozenset({"shared_key"})
+
+    def test_mutable_key_set_is_rejected(self):
+        # A mutable set could be edited into an overlap after __init_subclass__ has
+        # already passed, which a frozenset makes impossible.
+        with pytest.raises(TypeError, match="must be a frozenset"):
+
+            class MutableMetric(ValidMetric):
+                sparse_safe_keys = {"safe_key"}  # noqa: RUF012
+
+    def test_overlap_is_detected_through_inheritance(self):
+        # CTCMetrics inherits its keys from AOGMMetrics, so the check has to look at
+        # the resolved values rather than only what this class body declares.
+        class Parent(ValidMetric):
+            sparse_safe_keys = frozenset({"shared_key"})
+
+        with pytest.raises(ValueError, match="both sparse-safe and agnostic"):
+
+            class Child(Parent):
+                agnostic_keys = frozenset({"shared_key"})
+
     def test_classify_sparse_gt_surfaces_in_results(self):
         class MixedMetric(ValidMetric):
             sparse_safe_keys = frozenset({"safe_key"})

--- a/tests/metrics/test_sparse_safe_keys.py
+++ b/tests/metrics/test_sparse_safe_keys.py
@@ -106,6 +106,12 @@ DECLARED_KEY_CASES = [
 ]
 
 
+# Metrics that legitimately declare no sparse-safe or agnostic keys, so there is
+# nothing for DECLARED_KEY_CASES to pin. Listing them explicitly keeps a metric that
+# simply forgot to declare anything from passing as one of these.
+KEYLESS_METRICS = frozenset({CellCycleAccuracy, CHOTAMetric})
+
+
 @pytest.mark.filterwarnings(
     "ignore:Mapping is empty",
     "ignore:Node errors already calculated",
@@ -125,20 +131,6 @@ def test_declared_keys_are_actually_returned(metric_factory, cases):
         f"declared but never returned: {sorted(declared - produced)}. A renamed or "
         "misspelled key is silently treated as dense-only and dropped from sparse results."
     )
-
-
-def test_metrics_without_declared_keys_are_skipped_not_computed():
-    # CCA and CHOTA declare nothing, so under sparse ground truth they cannot report
-    # anything. Guards the list in the docs table against silently going stale.
-    for metric_class in (CellCycleAccuracy, CHOTAMetric):
-        assert not metric_class.sparse_safe_keys
-        assert not metric_class.agnostic_keys
-
-
-# Metrics that legitimately declare no sparse-safe or agnostic keys, so there is
-# nothing for DECLARED_KEY_CASES to pin. Listing them explicitly keeps a metric that
-# simply forgot to declare anything from passing as one of these.
-KEYLESS_METRICS = frozenset({CellCycleAccuracy, CHOTAMetric})
 
 
 def _metric_subclasses(cls: type) -> set[type]:
@@ -165,12 +157,13 @@ def test_every_metric_is_pinned_or_explicitly_keyless():
         f"neither pinned in DECLARED_KEY_CASES nor listed in KEYLESS_METRICS: {unaccounted}"
     )
 
-
-def test_leaf_keys_recurses():
-    assert _leaf_keys({"Frame Buffer 0": {"a": 1}, "b": 2}) == {"a", "b"}
-    assert _leaf_keys({}) == set()
-    # A list value (CompleteTracksByLength returns lists) is a leaf, not a container.
-    assert _leaf_keys({"accuracy": [1, 2]}) == {"accuracy"}
+    # The other direction: a metric listed as keyless that starts declaring keys would
+    # keep being waved through above while its keys went unpinned.
+    gained = sorted(c.__name__ for c in KEYLESS_METRICS if c.sparse_safe_keys or c.agnostic_keys)
+    assert not gained, (
+        f"listed in KEYLESS_METRICS but now declares keys, so it needs a "
+        f"DECLARED_KEY_CASES entry instead: {gained}"
+    )
 
 
 def test_declared_keys_survive_a_real_sparse_compute():

--- a/tests/metrics/test_sparse_safe_keys.py
+++ b/tests/metrics/test_sparse_safe_keys.py
@@ -2,10 +2,12 @@
 
 ``sparse_safe_keys``/``agnostic_keys`` repeat result-key strings that ``_compute`` builds
 independently -- ``BasicMetrics`` composes them with f-strings and never writes them as
-literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, and
-the failure is silent: an unrecognized key is classified ``dense_only`` and quietly dropped
-from sparse results, while a declared key that no longer exists is a dead no-op. These tests
-turn both into a test failure.
+literals, and ``DivisionMetrics`` writes them out twice. Nothing ties the two together, so
+renaming a key on one side leaves the other a dead no-op that drops out of sparse results
+without a word. These tests turn that into a test failure.
+
+Whether a single declaration is self-consistent -- no key claimed as both sparse-safe and
+agnostic -- is checked by ``Metric.__init_subclass__`` when the class is defined, not here.
 """
 
 import networkx as nx
@@ -29,18 +31,6 @@ from traccuracy.metrics import (
     TrackOverlapMetrics,
 )
 from traccuracy.metrics._base import Metric
-
-ALL_METRIC_CLASSES = [
-    AOGMMetrics,
-    BasicMetrics,
-    CHOTAMetric,
-    CTCMetrics,
-    CellCycleAccuracy,
-    CompleteTracks,
-    CompleteTracksByLength,
-    DivisionMetrics,
-    TrackOverlapMetrics,
-]
 
 
 def _division_matched():
@@ -137,13 +127,6 @@ def test_declared_keys_are_actually_returned(metric_factory, cases):
     )
 
 
-@pytest.mark.parametrize("metric_class", ALL_METRIC_CLASSES, ids=lambda c: c.__name__)
-def test_sparse_safe_and_agnostic_are_disjoint(metric_class):
-    # A key in both sets resolves to "sparse_safe" silently, hiding the contradiction.
-    overlap = metric_class.sparse_safe_keys & metric_class.agnostic_keys
-    assert not overlap, f"{metric_class.__name__} classifies {sorted(overlap)} as both"
-
-
 def test_metrics_without_declared_keys_are_skipped_not_computed():
     # CCA and CHOTA declare nothing, so under sparse ground truth they cannot report
     # anything. Guards the list in the docs table against silently going stale.
@@ -152,18 +135,35 @@ def test_metrics_without_declared_keys_are_skipped_not_computed():
         assert not metric_class.agnostic_keys
 
 
-def test_every_metric_subclass_is_covered():
-    # A new Metric subclass should be added to ALL_METRIC_CLASSES so its declared keys
-    # get checked rather than silently skipped.
-    subclasses = {c for c in Metric.__subclasses__() if c.__module__.startswith("traccuracy")}
-    subclasses |= {
-        sub
-        for c in subclasses
-        for sub in c.__subclasses__()
-        if sub.__module__.startswith("traccuracy")
-    }
-    uncovered = sorted(c.__name__ for c in subclasses - set(ALL_METRIC_CLASSES))
-    assert not uncovered, f"uncovered Metric subclasses: {uncovered}"
+# Metrics that legitimately declare no sparse-safe or agnostic keys, so there is
+# nothing for DECLARED_KEY_CASES to pin. Listing them explicitly keeps a metric that
+# simply forgot to declare anything from passing as one of these.
+KEYLESS_METRICS = frozenset({CellCycleAccuracy, CHOTAMetric})
+
+
+def _metric_subclasses(cls: type) -> set[type]:
+    """Every traccuracy Metric subclass, at any depth."""
+    found = set()
+    for sub in cls.__subclasses__():
+        if sub.__module__.startswith("traccuracy"):
+            found.add(sub)
+        found |= _metric_subclasses(sub)
+    return found
+
+
+def test_every_metric_is_pinned_or_explicitly_keyless():
+    # Metric.__init_subclass__ already rejects a self-contradictory declaration, but
+    # nothing drags a new metric into DECLARED_KEY_CASES, so its keys would never be
+    # checked against what _compute returns -- and a metric that declares nothing at
+    # all would quietly default to dense-only. Every metric has to land in one bucket.
+    # Each DECLARED_KEY_CASES entry must be a pytest.param so .values[0] is its factory.
+    pinned = {type(param.values[0]()) for param in DECLARED_KEY_CASES}
+    unaccounted = sorted(
+        c.__name__ for c in _metric_subclasses(Metric) if c not in pinned | KEYLESS_METRICS
+    )
+    assert not unaccounted, (
+        f"neither pinned in DECLARED_KEY_CASES nor listed in KEYLESS_METRICS: {unaccounted}"
+    )
 
 
 def test_leaf_keys_recurses():


### PR DESCRIPTION
Stacked on #363. Follows up on [cmalinmayor's comment](https://github.com/live-image-tracking-tools/traccuracy/pull/363#discussion_r-sparse-safe-keys) on `tests/metrics/test_sparse_safe_keys.py`:

> I do feel like these should be somehow in the `__init__` as like a post-init step? Or otherwise error at runtime and not just in the test suite?

Agreed, for the half of it that can move. It splits cleanly:

- **Whether a declaration is self-consistent** depends only on the class body, so it belongs at class-definition time. Moved to `Metric.__init_subclass__`.
- **Whether declared keys match what `_compute` returns** fundamentally needs data — `BasicMetrics` composes its keys at runtime with `f"{feature_type} Recall"` after `.capitalize()`, so nothing about them is knowable from the class body. Stays a test.

## What changed

`Metric.__init_subclass__` now raises when a subclass is *defined*, so a bad declaration is an import-time error rather than something that only surfaces if a test remembered to look:

- `ValueError` if a key is in both `sparse_safe_keys` and `agnostic_keys` (`_classify_sparse_safe` silently resolves such a key to sparse-safe).
- `TypeError` if either is not a `frozenset`. This one is load-bearing rather than fussy: a mutable `set` can be edited into an overlap *after* the check has run, so immutability is what makes the disjointness check mean anything. Rebinding the attribute entirely is still unchecked — this is a definition-time check, not an invariant.

Both use the MRO-resolved values, so `CTCMetrics` is validated against what it inherits from `AOGMMetrics`.

## Why `ALL_METRIC_CLASSES` goes away

Once the hook enforces disjointness, no subclass at any depth can escape it, and `ALL_METRIC_CLASSES` had no consumer left except the test asserting the list was complete — purely circular. So it and `test_sparse_safe_and_agnostic_are_disjoint` are deleted.

The completeness guard moves to the registry that *does* still need one. Nothing forced a new metric into `DECLARED_KEY_CASES`, so its keys would never have been pinned against `_compute`. The replacement:

- walks subclasses **recursively** instead of exactly two levels (the old walk was structurally blind below `Metric → AOGMMetrics → CTCMetrics`, which is as deep as the tree currently goes — so this is future-proofing, not a live bug);
- keeps the census the old test provided via an explicit `KEYLESS_METRICS`, so a metric that declares *nothing at all* is still flagged instead of quietly defaulting to dense-only.

Net effect for a contributor adding a metric: one list to touch instead of two, and a loud error instead of a silently-skipped test.

## Also trimmed the file

Two of the five tests left in `tests/metrics/test_sparse_safe_keys.py` weren't earning their place, and cmalinmayor flagged one of them directly:

- `test_leaf_keys_recurses` only exercised this file's own flattening helper — the test suite talking to itself. Deleted; every `DECLARED_KEY_CASES` case already runs that helper for real.
- `test_metrics_without_declared_keys_are_skipped_not_computed` never checked skipping despite its name, and hardcoded the same `(CellCycleAccuracy, CHOTAMetric)` pair that `KEYLESS_METRICS` lists a few lines below. It wasn't redundant, though — it was really the *reverse* direction of the census: a metric listed as keyless that later starts declaring keys would keep being waved through while its keys went unpinned. That check moved into `test_every_metric_is_pinned_or_explicitly_keyless` and now reads `KEYLESS_METRICS` instead of a second copy of the pair.

`KEYLESS_METRICS` also moves up beside `DECLARED_KEY_CASES` so both registries can be read together. Five tests down to three.

## Test plan

- [x] Full suite: 723 passed. The one failure, `tests/loaders/test_geff.py::test_load_rel_obj`, is pre-existing on #363's head and unrelated (geff `RelatedObject.node_prop` API drift).
- [x] `pre-commit run --files <changed>`: typos, ruff, ruff-format, mypy all pass.
- [x] Mutation-tested the three new tests in `test_base.py` — no-op'ing the hook fails all three; dropping only the type check fails only `test_mutable_key_set_is_rejected`.
- [x] Confirmed the new census guard fires on both a keyed and a keyless injected metric, and that the old two-level walk missed an injected level-3 subclass the recursive one catches.
- [x] Checked for test-ordering leakage: at the moment the guard runs in a full session, the only non-traccuracy `Metric` subclasses alive are the test-local ones, all rejected by the module filter. Passes in both file orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

